### PR TITLE
Implement address specification

### DIFF
--- a/manifests/director.pp
+++ b/manifests/director.pp
@@ -16,6 +16,7 @@
 #
 class bacula::director (
   $port                = '9101',
+  $listen_address      = $::ipaddress,
   $db_user             = $bacula::params::bacula_user,
   $db_pw               = 'notverysecret',
   $db_name             = $bacula::params::bacula_user,

--- a/manifests/storage.pp
+++ b/manifests/storage.pp
@@ -4,9 +4,9 @@
 #
 class bacula::storage (
   $port                    = '9103',
-  $password                = 'secret',
   $listen_address          = $::ipaddress,
   $storage                 = $::fqdn,
+  $password                = 'secret',
   $device_name             = "${::fqdn}-device",
   $device                  = '/bacula',
   $device_owner            = $bacula::params::bacula_user,

--- a/templates/bacula-dir-header.erb
+++ b/templates/bacula-dir-header.erb
@@ -1,6 +1,13 @@
 Director {                # define myself
     Name                    = <%= @clientcert %>-dir
-    DIRport                 = <%= @port %>  # where we listen for UA connections
+    DirAddresses            = { ip = {
+<% if @listen_address -%>
+                                addr = <%= @listen_address %>;
+<% end -%>
+<% if @port -%>
+                                port = <%= @port %>;
+<% end -%>
+                              } }
     QueryFile               = "/etc/bacula/scripts/query.sql"
     WorkingDirectory        = <%= @homedir %>
     Pid Directory           = <%= @rundir %>

--- a/templates/bacula-fd-header.erb
+++ b/templates/bacula-fd-header.erb
@@ -21,8 +21,14 @@ Director {
 
 FileDaemon {
     Name                    = <%= @clientcert %>-fd
-    FDAddress               = <%= @listen_address %>
-    FDport                  = <%= @port %>
+    FDAddresses            = { ip = {
+<% if @listen_address -%>
+                                addr = <%= @listen_address %>;
+<% end -%>
+<% if @port -%>
+                                port = <%= @port %>;
+<% end -%>
+                              } }
     WorkingDirectory        = <%= @homedir %>
     Pid Directory           = <%= @rundir %>
     Maximum Concurrent Jobs = <%= @max_concurrent_jobs %>

--- a/templates/bacula-sd-header.erb
+++ b/templates/bacula-sd-header.erb
@@ -2,7 +2,14 @@ Storage {
     Name                    = <%= @clientcert %>-sd
     WorkingDirectory        = <%= @homedir %>
     Pid Directory           = <%= @rundir %>
-    SDPort                  = <%= @port %>
+    SDAddresses            = { ip = {
+<% if @listen_address -%>
+                                addr = <%= @listen_address %>;
+<% end -%>
+<% if @port -%>
+                                port = <%= @port %>;
+<% end -%>
+                              } }
 <%= scope.function_template(['bacula/_ssl.erb']) %>
 <%= scope.function_template(['bacula/_sslkeypair.erb']) %>
 <% if scope.lookupvar('bacula::params::ssl') -%>


### PR DESCRIPTION
This work allows the user to specify the address to listen on for each
daemon.  This also adds the ability to move a Bacula installation to
run entirely over IPv6.