### PR TITLE
Two feature enhancements and three small fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,10 @@ resources if needed. Parameters are:
 - `accurate`: whether to enable accurate mode. NB, can be memory intensive
   on the client.
   Defaults to 'no'. Bacula 'Accurate' directive.
+- `messages`: the name of the message resource to use for this job.
+  Defaults to `Standard`. Bacula `Message` directive.
+- `restoredir`: the prefix for restore jobs.
+  Defaults to `/tmp/bacula-restores`.
 
 See also `bacula::jobdefs`.
 

--- a/README.md
+++ b/README.md
@@ -124,9 +124,16 @@ resources if needed. Parameters are:
   on the client.
   Defaults to 'no'. Bacula 'Accurate' directive.
 - `messages`: the name of the message resource to use for this job.
-  Defaults to `Standard`. Bacula `Messages` directive.
+  Defaults to `false` which disables this directive. Bacula `Messages` directive.
+  To ensure compatibility with existing installations, the Bacula `Messages`
+  directive is set to `Standard` when `Jobtype` is `Restore` and the `messages`
+  parameter is `false`.
 - `restoredir`: the prefix for restore jobs.
   Defaults to `/tmp/bacula-restores`. Bacula `Where` directive.
+- `sched`: the name of the scheduler resource to use for this job.
+  Defaults to `false` which disables this directive. Bacula `Schedule` directive.
+- `priority`: the priority of the job.
+  Defaults to `false` which disables this directive. Bacula `Priority` directive.
 
 See also `bacula::jobdefs`.
 

--- a/README.md
+++ b/README.md
@@ -124,9 +124,9 @@ resources if needed. Parameters are:
   on the client.
   Defaults to 'no'. Bacula 'Accurate' directive.
 - `messages`: the name of the message resource to use for this job.
-  Defaults to `Standard`. Bacula `Message` directive.
+  Defaults to `Standard`. Bacula `Messages` directive.
 - `restoredir`: the prefix for restore jobs.
-  Defaults to `/tmp/bacula-restores`.
+  Defaults to `/tmp/bacula-restores`. Bacula `Where` directive.
 
 See also `bacula::jobdefs`.
 

--- a/manifests/director.pp
+++ b/manifests/director.pp
@@ -121,5 +121,6 @@ class bacula::director (
   bacula::job { 'RestoreFiles':
     jobtype => 'Restore',
     fileset => false,
+    jobdef  => false,
   }
 }

--- a/manifests/director.pp
+++ b/manifests/director.pp
@@ -119,8 +119,9 @@ class bacula::director (
   }
 
   bacula::job { 'RestoreFiles':
-    jobtype => 'Restore',
-    fileset => false,
-    jobdef  => false,
+    jobtype  => 'Restore',
+    fileset  => false,
+    jobdef   => false,
+    messages => 'Standard',
   }
 }

--- a/manifests/director/postgresql.pp
+++ b/manifests/director/postgresql.pp
@@ -22,6 +22,7 @@ class bacula::director::postgresql(
     user     => $db_user,
     password => postgresql_password($db_user, $db_pw),
     encoding => 'SQL_ASCII',
+    locale   => 'C',
   }
 
   file { $make_bacula_tables:

--- a/manifests/job.pp
+++ b/manifests/job.pp
@@ -18,7 +18,12 @@
 #   * reshedule_interval - string time-spec for job option "Reschedule Interval"
 #   * reshedule_times - string count for job option "Reschedule Times"
 #   * messages - string containing the name of the message resource to use for this job
+#     set to false to disable this option
 #   * restoredir - string containing the prefix for restore jobs
+#   * sched - string containing the name of the scheduler
+#     set to false to disable this option
+#   * priority - string containing the priority number for the job
+#     set to false to disable this option
 #
 # Actions:
 #   * Exports job fragment for consuption on the director
@@ -50,8 +55,10 @@ define bacula::job (
   $reschedule_on_error = false,
   $reschedule_interval = '1 hour',
   $reschedule_times    = '10',
-  $messages            = 'Standard',
+  $messages            = false,
   $restoredir          = '/tmp/bacula-restores',
+  $sched               = false,
+  $priority            = false,
 ) {
   validate_array($files)
   validate_array($excludes)

--- a/manifests/job.pp
+++ b/manifests/job.pp
@@ -17,6 +17,8 @@
 #   * reshedule_on_error - boolean for enableing disabling job option "Reschedule On Error"
 #   * reshedule_interval - string time-spec for job option "Reschedule Interval"
 #   * reshedule_times - string count for job option "Reschedule Times"
+#   * messages - string containing the name of the message resource to use for this job
+#   * restoredir - string containing the prefix for restore jobs
 #
 # Actions:
 #   * Exports job fragment for consuption on the director
@@ -48,6 +50,8 @@ define bacula::job (
   $reschedule_on_error = false,
   $reschedule_interval = '1 hour',
   $reschedule_times    = '10',
+  $messages            = 'Standard',
+  $restoredir          = '/tmp/bacula-restores',
 ) {
   validate_array($files)
   validate_array($excludes)

--- a/manifests/storage.pp
+++ b/manifests/storage.pp
@@ -78,6 +78,7 @@ class bacula::storage (
       owner  => $device_owner,
       group  => $group,
       mode   => '0770',
+      require   => Package[$packages],
     }
   }
 

--- a/templates/fileset.conf.erb
+++ b/templates/fileset.conf.erb
@@ -2,8 +2,10 @@ FileSet {
   Name = <%= @name %>
   Include {
     Options {
-<% @options.each do |option,value| -%>
+<% @options.each do |option,optval| -%>
+<%   [optval].flatten.each do |value| -%>
 <%=    "      #{option} = #{value}" %>
+<%   end -%>
 <% end -%>
     }
 <% [@files].flatten.each do |f| -%>

--- a/templates/job.conf.erb
+++ b/templates/job.conf.erb
@@ -6,7 +6,9 @@ Job {
     Pool             = <%= @pool %>
 <% if @jobtype == "Restore" -%>
     Where            = <%= @restoredir %>
-    Messages         = <%= @messages %>
+<%   if !@messages -%>
+    Messages         = Standard
+<%   end -%>
 <% elsif @jobtype == "Backup" -%>
     Full Backup Pool        = <%= scope.lookupvar('bacula::params::bacula_storage') %>-Pool-Full
     Incremental Backup Pool = <%= scope.lookupvar('bacula::params::bacula_storage') %>-Pool-Inc
@@ -27,6 +29,15 @@ Job {
     Accurate         = <%= @accurate %>
 <% if @level -%>
     Level            = <%= @level %>
+<% end -%>
+<% if @messages -%>
+    Messages         = <%= @messages %>
+<% end -%>
+<% if @sched -%>
+    Schedule         = <%= @sched %>
+<% end -%>
+<% if @priority -%>
+    Priority         = <%= @priority %>
 <% end -%>
 <%= scope.function_template(['bacula/_job_reschedule.erb']) -%>
 }

--- a/templates/job.conf.erb
+++ b/templates/job.conf.erb
@@ -5,8 +5,8 @@ Job {
     FileSet          = <%= @fileset_real %>
     Pool             = <%= @pool %>
 <% if @jobtype == "Restore" -%>
-    Where            = /tmp/bacula-restores
-    Messages         = Standard
+    Where            = <%= @restoredir %>
+    Messages         = <%= @messages %>
 <% elsif @jobtype == "Backup" -%>
     Full Backup Pool        = <%= scope.lookupvar('bacula::params::bacula_storage') %>-Pool-Full
     Incremental Backup Pool = <%= scope.lookupvar('bacula::params::bacula_storage') %>-Pool-Inc


### PR DESCRIPTION
Hi,
this module work's now great on my RHEL servers, but there were 3 minor issues I fixed:
+ `Ctype` and `Collate` of the database was set to `UTF-8`, the bacula database create script sets it to `C`. I'm not a database expert, but I think `C` makes more sense with `SQL_ASCII` encoding.
+ There was a missing dependency in one file resource in the storage class.
+ The `RestoreFile` job had the `Default` schedule and failed every night.

I also added two features:
+ I have to use fileset options like `wild` multiple times, so I added support for arrays as values of the options hash.
+ I need two restore jobs with different output directories, one for the usual file restore while the os is running, and one fore bare metal recovery. So I made `Where` configurable in the job type. I also did this for `Messages` because after changing `Where` it was the last static parameter in the template.

I testet all of these changes in my environment and found no issues. I also did compatibility tests to make sure existing installations will have no problems with this changes.