### PR TITLE
allow to overwrite the ssl_dir parameter

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -23,8 +23,13 @@ class bacula::params {
   if $::is_pe == true {
     $ssl_dir = '/etc/puppetlabs/puppet/ssl'
   } else {
-    include puppet::params
-    $ssl_dir = $puppet::params::puppet_ssldir
+    $ssl_dir_hiera = hiera('bacula::params::ssl_dir', undef)
+    if ( $ssl_dir_hiera != undef ) {
+      $ssl_dir = $ssl_dir_hiera
+    } else {
+      include puppet::params
+      $ssl_dir = $puppet::params::puppet_ssldir
+    }
   }
 
   case $::operatingsystem {


### PR DESCRIPTION
This PR makes it possible to overwrite the `ssl_dir` parameter from hiera:

```
bacula::params::ssl: true
bacula::params::ssl_dir: '/foo/bar/puppet/ssl'
```

I think this aligns well with the other hiera configurable parameters. And as a bonus, it loosens the dependency on `lpoperations/puppet` and makes it possible to use any other module to configure puppet (i.e. `theforeman/puppet`, which I strongly prefer).

This commit shouldn't break anything.