### PR TITLE
Update conf_dir paths

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -17,6 +17,7 @@ class bacula::client (
   $director            = $bacula::params::bacula_director,
   $group               = $bacula::params::bacula_group,
   $client_config       = $bacula::params::client_config,
+  $client              = $::fqdn,
 ) inherits bacula::params {
 
   include bacula::common
@@ -53,9 +54,9 @@ class bacula::client (
   }
 
   # Tell the director about this client config
-  @@concat::fragment { "bacula-client-${::fqdn}":
-    target  => '/etc/bacula/conf.d/client.conf',
-    content => template('bacula/client.conf.erb'),
-    tag     => "bacula-${bacula::params::bacula_director}",
+  @@bacula::director::client { $client:
+    port     => $port,
+    client   => $client,
+    password => $password,
   }
 }

--- a/manifests/director.pp
+++ b/manifests/director.pp
@@ -97,19 +97,22 @@ class bacula::director (
 
   Bacula::Director::Pool <<||>> { conf_dir => $conf_dir }
   Bacula::Director::Storage <<||>> { conf_dir => $conf_dir }
+  Bacula::Director::Client <<||>> { conf_dir => $conf_dir }
+
+  Bacula::Fileset <<||>> { conf_dir => $conf_dir }
 
   Concat::Fragment <<| tag == "bacula-${director_name}" |>>
 
   concat { "${conf_dir}/bacula-dir.conf": }
 
   $sub_confs = [
-    '/etc/bacula/conf.d/schedule.conf',
-    '/etc/bacula/conf.d/storage.conf',
-    '/etc/bacula/conf.d/pools.conf',
-    '/etc/bacula/conf.d/job.conf',
-    '/etc/bacula/conf.d/jobdefs.conf',
-    '/etc/bacula/conf.d/client.conf',
-    '/etc/bacula/conf.d/fileset.conf',
+    "${conf_dir}/conf.d/schedule.conf",
+    "${conf_dir}/conf.d/storage.conf",
+    "${conf_dir}/conf.d/pools.conf",
+    "${conf_dir}/conf.d/job.conf",
+    "${conf_dir}/conf.d/jobdefs.conf",
+    "${conf_dir}/conf.d/client.conf",
+    "${conf_dir}/conf.d/fileset.conf",
   ]
 
   concat { $sub_confs: }

--- a/manifests/director/client.pp
+++ b/manifests/director/client.pp
@@ -1,0 +1,15 @@
+define bacula::director::client (
+  $port           = '9102',
+  $client         = $::fqdn,
+  $password       = 'secret',
+  $conf_dir       = $bacula::params::conf_dir, # Overridden at realize
+  $file_retention = $bacula::params::file_retention,
+  $job_retention  = $bacula::params::job_retention,
+  $autoprune      = $bacula::params::autoprune,
+) {
+
+  concat::fragment { "bacula-director-client-${client}":
+    target  => "${conf_dir}/conf.d/client.conf",
+    content => template('bacula/bacula-dir-client.erb'),
+  }
+}

--- a/manifests/fileset.pp
+++ b/manifests/fileset.pp
@@ -6,13 +6,14 @@ define bacula::fileset (
     $files,
     $excludes = '',
     $options  = {'signature' => 'MD5', 'compression' => 'GZIP'},
+    $conf_dir = $bacula::params::conf_dir, # Overridden at realize
   ) {
   validate_hash($options)
 
   include bacula::common
 
   @@concat::fragment { "bacula-fileset-${name}":
-    target  => '/etc/bacula/conf.d/fileset.conf',
+    target  => "${conf_dir}/conf.d/fileset.conf",
     content => template('bacula/fileset.conf.erb'),
     tag     => "bacula-${bacula::params::bacula_director}";
   }

--- a/manifests/job.pp
+++ b/manifests/job.pp
@@ -68,6 +68,7 @@ define bacula::job (
 
   include bacula::common
   include bacula::params
+  $conf_dir = $bacula::params::conf_dir
 
   # if the fileset is not defined, we fall back to one called "Common"
   if is_string($fileset) {
@@ -84,7 +85,7 @@ define bacula::job (
   }
 
   @@concat::fragment { "bacula-job-${name}":
-    target  => '/etc/bacula/conf.d/job.conf',
+    target  => "${conf_dir}/conf.d/job.conf",
     content => template($template),
     tag     => "bacula-${::bacula::params::bacula_director}";
   }

--- a/manifests/jobdefs.pp
+++ b/manifests/jobdefs.pp
@@ -22,10 +22,14 @@ define bacula::jobdefs (
   $reschedule_interval = '1 hour',
   $reschedule_times    = '10',
 ) {
+
   validate_re($jobtype, ['^Backup', '^Restore', '^Admin', '^Verify'])
 
+  include bacula::params
+  $conf_dir = $bacula::params::conf_dir
+
   concat::fragment { "bacula-jobdefs-${name}":
-    target  => '/etc/bacula/conf.d/jobdefs.conf',
+    target  => "${conf_dir}/conf.d/jobdefs.conf",
     content => template('bacula/jobdefs.conf.erb'),
   }
 }

--- a/manifests/schedule.pp
+++ b/manifests/schedule.pp
@@ -3,13 +3,14 @@
 # Creates a schedule to which jobs and jobdefs can adhere.
 #
 define bacula::schedule (
-  $runs
+  $runs,
+  $conf_dir = $bacula::params::conf_dir,
 ) {
 
   validate_array($runs)
 
   concat::fragment { "bacula-schedule-${name}":
-    target  => '/etc/bacula/conf.d/schedule.conf',
+    target  => "${conf_dir}/conf.d/schedule.conf",
     content => template('bacula/schedule.conf.erb'),
   }
 }

--- a/templates/bacula-dir-client.erb
+++ b/templates/bacula-dir-client.erb
@@ -1,5 +1,5 @@
 Client {
-    Name           = <%= @clientcert %>-fd
+    Name           = <%= @client %>-fd
     Address        = <%= @clientcert %>
     FDPort         = <%= @port %>
     Catalog        = MyCatalog

--- a/templates/bacula-dir-tail.erb
+++ b/templates/bacula-dir-tail.erb
@@ -1,7 +1,7 @@
-@/etc/bacula/conf.d/schedule.conf
-@/etc/bacula/conf.d/storage.conf
-@/etc/bacula/conf.d/pools.conf
-@/etc/bacula/conf.d/client.conf
-@/etc/bacula/conf.d/fileset.conf
-@/etc/bacula/conf.d/jobdefs.conf
-@/etc/bacula/conf.d/job.conf
+@<%= @conf_dir %>/conf.d/schedule.conf
+@<%= @conf_dir %>/conf.d/storage.conf
+@<%= @conf_dir %>/conf.d/pools.conf
+@<%= @conf_dir %>/conf.d/client.conf
+@<%= @conf_dir %>/conf.d/fileset.conf
+@<%= @conf_dir %>/conf.d/jobdefs.conf
+@<%= @conf_dir %>/conf.d/job.conf


### PR DESCRIPTION
This work ensures that there is seperation between the param data
between components of the system in multi-platform environments where
paths may differ.

Without this change, the director needs to be on a system where the
conf_dir path is under /etc.  This work also shifts the exported
resource on the client to its own define to allow the ability to
override the conf_dir path on the director at realization.