### PR TITLE
Ensure lowercase IPv6 addresses

### DIFF
--- a/templates/bacula-dir-header.erb
+++ b/templates/bacula-dir-header.erb
@@ -2,7 +2,7 @@ Director {                # define myself
     Name                    = <%= @clientcert %>-dir
     DirAddresses            = { ip = {
 <% if @listen_address -%>
-                                addr = <%= @listen_address %>;
+                                addr = <%= @listen_address.downcase %>;
 <% end -%>
 <% if @port -%>
                                 port = <%= @port %>;

--- a/templates/bacula-fd-header.erb
+++ b/templates/bacula-fd-header.erb
@@ -23,7 +23,7 @@ FileDaemon {
     Name                    = <%= @clientcert %>-fd
     FDAddresses            = { ip = {
 <% if @listen_address -%>
-                                addr = <%= @listen_address %>;
+                                addr = <%= @listen_address.downcase %>;
 <% end -%>
 <% if @port -%>
                                 port = <%= @port %>;

--- a/templates/bacula-sd-header.erb
+++ b/templates/bacula-sd-header.erb
@@ -4,7 +4,7 @@ Storage {
     Pid Directory           = <%= @rundir %>
     SDAddresses            = { ip = {
 <% if @listen_address -%>
-                                addr = <%= @listen_address %>;
+                                addr = <%= @listen_address.downcase %>;
 <% end -%>
 <% if @port -%>
                                 port = <%= @port %>;


### PR DESCRIPTION
This work fixes a change when the fact values for an IP address are
returned in uppercase causing a configuration change, even when the
address is the same, triggering a restart.