### PR TITLE
Allow tunning for storage job concurrency

### DIFF
--- a/manifests/director/storage.pp
+++ b/manifests/director/storage.pp
@@ -4,24 +4,27 @@
 # This define creates a storage declaration for the
 # director.  This informs the director which storage
 # servers are available to send client backups to.
+#
 # This resource is intended to be used from
 # bacula::storage as an exported resource, so that
 # each storage server is available as a configuration
 # on the director.
 #
 # Parameters:
-# *  port        - Bacula storage configuration option 'SDPort'
-# *  password    - Bacula storage configuration option 'Password'
-# *  device_name - Bacula storage configuration option 'Device'
-# *  media_type  - Bacula storage configuration option 'Media Type'
+# *  port         - Bacula director configuration for Storage option 'SDPort'
+# *  password     - Bacula director configuration for Storage option 'Password'
+# *  device_name  - Bacula director configuration for Storage option 'Device'
+# *  media_type   - Bacula director configuration for Storage option 'Media Type'
+# *  maxconcurjob - Bacula director configuration for Storage option 'Media Type'
 #
 define bacula::director::storage (
-  $port        = '9103',
-  $password    = 'secret',
-  $storage     = $::fqdn,
-  $device_name = "${::fqdn}-device",
-  $media_type  = 'File',
-  $conf_dir    = $bacula::params::conf_dir, # Overridden at realize
+  $port          = '9103',
+  $password      = 'secret',
+  $storage       = $::fqdn,
+  $device_name   = "${::fqdn}-device",
+  $media_type    = 'File',
+  $maxconcurjobs = '1',
+  $conf_dir      = $bacula::params::conf_dir, # Overridden at realize
 ) {
 
   include bacula::params

--- a/manifests/storage.pp
+++ b/manifests/storage.pp
@@ -83,11 +83,12 @@ class bacula::storage (
   }
 
   @@bacula::director::storage { "${storage}-sd":
-    port        => $port,
-    password    => $password,
-    device_name => $device_name,
-    media_type  => $media_type,
-    storage     => $storage,
+    port          => $port,
+    password      => $password,
+    device_name   => $device_name,
+    media_type    => $media_type,
+    storage       => $storage,
+    maxconcurjobs => $maxconcurjobs
   }
 
   # Each storage daemon should get its own pool(s)

--- a/templates/bacula-dir-storage.erb
+++ b/templates/bacula-dir-storage.erb
@@ -5,6 +5,7 @@ Storage {
     Password   = "<%= @password %>"
     Device     = <%= @device_name %>
     Media Type = <%= @media_type %>
+    Maximum Concurrent Jobs = <%= @maxconcurjobs %>
 <%= scope.function_template(['bacula/_ssl.erb']) %>
 <%= scope.function_template(['bacula/_sslkeypair.erb']) %>
 }


### PR DESCRIPTION
Without this change, the default of 1 job per storage device is used and
the user is unable to change this value.

This work adds the param to the director class and passes in the value
that is already been supplied to the bacula::storage class.