### PR TITLE
Update SSL deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,33 @@ of Bacula (Director, Storage, and Client) all run on three separate nodes.  If
 desired, there is no reason this setup can not be build up on a single node,
 just updating the hostnames used below to all point to the same system.
 
+#### SSL
+
+To enable SSL for the communication between the various components of Bacula,
+the hiera data for SSL must be set.
+
+```yaml
+bacula::params::ssl: true
+```
+
+This will ensure that SSL values are processed in the various templates that
+are capable of SSL communication.  An item of note: this module expects to be
+using the SSL directory for Puppet.  The default value for the Puppet SSL
+directory this module will use is `/etc/puppetlabs/puppet/ssl` to support the
+future unified Puppet deployment.
+
+To change the SSL directory, simply set `bacula::params::ssl_dir`.  For
+example, to use another module for the data source of which SSL directory to
+use for Puppet, something like the following is in order.
+
+```yaml
+bacula::params::ssl_dir: "%{scope('puppet::params::puppet_ssldir')}"
+```
+
+This example assumes that you are using the [ploperations/puppet] module, but
+this has been removed as a requirement as a dependency.  Users may also wish to
+look at [theforeman/puppet].
+
 #### Director Setup
 
 The director component handles coordination of backups and databasing of
@@ -229,4 +256,7 @@ Define a Bacula [Pool resource]. Parameters are:
 [Pool resource]: http://www.bacula.org/7.0.x-manuals/en/main/Configuring_Director.html#SECTION0015150000000000000000
 [Schedule resource]: http://www.bacula.org/7.0.x-manuals/en/main/Configuring_Director.html#SECTION001550000000000000000
 [Job resource]: http://www.bacula.org/7.0.x-manuals/en/main/Configuring_Director.html#SECTION001530000000000000000
-[Messages resource]:http://www.bacula.org/7.0.x-manuals/en/main/Configuring_Director.html#SECTION001530000000000000000
+[Messages resource]: http://www.bacula.org/7.0.x-manuals/en/main/Configuring_Director.html#SECTION001530000000000000000
+[ploperations/puppet]: https://forge.puppetlabs.com/ploperations/puppet
+[theforeman/puppet]: https://forge.puppetlabs.com/theforeman/puppet
+

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -9,6 +9,9 @@ class bacula::params {
   $autoprune      = 'yes'
   $monitor        = true
   $ssl            = hiera('bacula::params::ssl', false)
+  $ssl_dir        = hiera('bacula::params::ssl_dir', '/etc/puppetlabs/puppet/ssl')
+
+  validate_bool($ssl)
 
   if $::operatingsystem in ['RedHat', 'CentOS', 'Fedora'] {
     $db_type        = hiera('bacula::params::db_type', 'postgresql')
@@ -19,13 +22,6 @@ class bacula::params {
   $bacula_storage   = hiera('bacula::params::bacula_storage', undef)
   $director_name    = hiera('bacula::params::director_name', $bacula_director)
   $director_address = hiera('bacula::params::director_address', $director_name)
-
-  if $::is_pe == true {
-    $ssl_dir = '/etc/puppetlabs/puppet/ssl'
-  } else {
-    include puppet::params
-    $ssl_dir = $puppet::params::puppet_ssldir
-  }
 
   case $::operatingsystem {
     'Ubuntu','Debian': {

--- a/metadata.json
+++ b/metadata.json
@@ -11,7 +11,6 @@
   "dependencies": [
     {"name":"puppetlabs/concat","version_requirement":">=1.0.0"},
     {"name":"puppetlabs/stdlib","version_requirement":">=4.4.0"},
-    {"name":"ploperations/puppet","version_requirement":">=0.12.0"},
     {"name":"puppetlabs/postgresql","version_requirement":">=4.1.0"}
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
This work removes the ploperations/puppet module as a dependency and
requires the user to specify the SSL directory in hiera.