### PR TITLE
Fixed an error in the bacula-dir-client template

### DIFF
--- a/templates/bacula-dir-client.erb
+++ b/templates/bacula-dir-client.erb
@@ -1,6 +1,6 @@
 Client {
     Name           = <%= @client %>-fd
-    Address        = <%= @clientcert %>
+    Address        = <%= @client %>
     FDPort         = <%= @port %>
     Catalog        = MyCatalog
     Password       = "<%= @password %>"


### PR DESCRIPTION
Hi,

while testing the new version I discovered that my client resource had the FQDN of the director in the __Address__ field.