### PR TITLE
Make storage device mode a param for the class

### DIFF
--- a/manifests/storage.pp
+++ b/manifests/storage.pp
@@ -9,6 +9,7 @@ class bacula::storage (
   $password                = 'secret',
   $device_name             = "${::fqdn}-device",
   $device                  = '/bacula',
+  $device_mode             = '0770',
   $device_owner            = $bacula::params::bacula_user,
   $media_type              = 'File',
   $maxconcurjobs           = '5',
@@ -69,7 +70,7 @@ class bacula::storage (
       ensure  => directory,
       owner   => $device_owner,
       group   => $group,
-      mode    => '0770',
+      mode    => $device_mode,
       require => Package[$packages],
     }
   }

--- a/templates/messages.erb
+++ b/templates/messages.erb
@@ -14,14 +14,14 @@ Messages {
 <% if @console -%>
     Console  = <%= @console %>
 <% end -%>
+<% if @mailcmd -%>
+    Mail Command  = <%= @mailcmd %>
+<% end -%>
 <% if @mail -%>
     Mail  = <%= @mail %>
 <% end -%>
 <% if @operator -%>
     Operator  = <%= @operator %>
-<% end -%>
-<% if @mailcmd -%>
-    Mail Command  = <%= @mailcmd %>
 <% end -%>
 <% if @operatorcmd -%>
     Operator Command = <%= @operatorcmd %>


### PR DESCRIPTION
This small change will allow the device mode to be overridden.. 

I needed this because a nfs share I use for file backups doesn't allow anything other than '0750'.