### PR TITLE
specify the db host

### DIFF
--- a/manifests/director.pp
+++ b/manifests/director.pp
@@ -6,6 +6,7 @@
 # * db_user: the database user
 # * db_pw: the database user's password
 # * db_name: the database name
+# * db_host: the database host
 # * password: password to connect to the director
 #
 # Sample Usage:
@@ -21,6 +22,7 @@ class bacula::director (
   $db_pw               = 'notverysecret',
   $db_name             = $bacula::params::bacula_user,
   $db_type             = $bacula::params::db_type,
+  $db_host             = $bacula::params::db_host,
   $password            = 'secret',
   $max_concurrent_jobs = '20',
   $packages            = $bacula::params::bacula_director_packages,
@@ -33,7 +35,6 @@ class bacula::director (
   $storage             = $bacula::params::storage,
   $group               = $bacula::params::bacula_group,
 ) inherits bacula::params {
-
   include bacula::common
   include bacula::client
   include bacula::ssl

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -13,6 +13,8 @@ class bacula::params {
 
   validate_bool($ssl)
 
+  $db_host        = hiera('bacula::params::db_host', 'localhost')
+
   if $::operatingsystem in ['RedHat', 'CentOS', 'Fedora'] {
     $db_type        = hiera('bacula::params::db_type', 'postgresql')
   } else {

--- a/templates/bacula-dir-header.erb
+++ b/templates/bacula-dir-header.erb
@@ -32,5 +32,6 @@ Catalog {
     Name   = MyCatalog
     dbname = "<%= @db_name %>";
     dbuser = "<%= @db_user %>";
-    dbpassword = "<%= @db_pw %>"
+    dbpassword = "<%= @db_pw %>";
+    DB Address = "<%= @db_host %>"
 }


### PR DESCRIPTION
add option to specify the database host for the director to connect to (this is important for postgres where the default is to only allow "peer" connections and to use a password, you have to use "localhost" or an ip address).

Connecting bacula to postgres 9.5 without the host is giving this error:

```
 >FATAL:  Peer authentication failed for user "bacula"
 >DETAIL:  Connection matched pg_hba.conf line 11: "local	all	all		ident	"
```

because of these default pg_hba rules:
```
# This file is managed by Puppet. DO NOT EDIT.

# Rule Name: local access as postgres user
# Description: none
# Order: 001
local	all	postgres		ident	

# Rule Name: local access to database with same name
# Description: none
# Order: 002
local	all	all		ident	
```


