### PR TITLE
Add options to specify the database host and port

### DIFF
--- a/manifests/director.pp
+++ b/manifests/director.pp
@@ -7,6 +7,7 @@
 # * db_pw: the database user's password
 # * db_name: the database name
 # * db_host: the database host
+# * db_port: the database port
 # * password: password to connect to the director
 #
 # Sample Usage:
@@ -23,6 +24,7 @@ class bacula::director (
   $db_name             = $bacula::params::bacula_user,
   $db_type             = $bacula::params::db_type,
   $db_host             = $bacula::params::db_host,
+  $db_port             = $bacula::params::db_port,
   $password            = 'secret',
   $max_concurrent_jobs = '20',
   $packages            = $bacula::params::bacula_director_packages,

--- a/manifests/director.pp
+++ b/manifests/director.pp
@@ -6,6 +6,7 @@
 # * db_user: the database user
 # * db_pw: the database user's password
 # * db_name: the database name
+# * db_host: the database host
 # * password: password to connect to the director
 #
 # Sample Usage:
@@ -21,6 +22,7 @@ class bacula::director (
   $db_pw               = 'notverysecret',
   $db_name             = $bacula::params::bacula_user,
   $db_type             = $bacula::params::db_type,
+  $db_host             = $bacula::params::db_host,
   $password            = 'secret',
   $max_concurrent_jobs = '20',
   $packages            = $bacula::params::bacula_director_packages,
@@ -33,7 +35,6 @@ class bacula::director (
   $storage             = $bacula::params::storage,
   $group               = $bacula::params::bacula_group,
 ) inherits bacula::params {
-
   include bacula::common
   include bacula::client
   include bacula::ssl

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -13,7 +13,8 @@ class bacula::params {
 
   validate_bool($ssl)
 
-  $db_host        = hiera('bacula::params::db_host', 'localhost')
+  $db_host        = hiera('bacula::params::db_host', undef)
+  $db_port        = hiera('bacula::params::db_port', undef)
 
   if $::operatingsystem in ['RedHat', 'CentOS', 'Fedora', 'Scientific'] {
     $db_type        = hiera('bacula::params::db_type', 'postgresql')

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -13,6 +13,8 @@ class bacula::params {
 
   validate_bool($ssl)
 
+  $db_host        = hiera('bacula::params::db_host', 'localhost')
+
   if $::operatingsystem in ['RedHat', 'CentOS', 'Fedora'] {
     $db_type        = hiera('bacula::params::db_type', 'postgresql')
   } else {

--- a/templates/bacula-dir-header.erb
+++ b/templates/bacula-dir-header.erb
@@ -33,5 +33,10 @@ Catalog {
     dbname = "<%= @db_name %>";
     dbuser = "<%= @db_user %>";
     dbpassword = "<%= @db_pw %>";
-    DB Address = "<%= @db_host %>"
+<% if not @db_host.nil? -%>
+    DB Address = "<%= @db_host %>";
+<% end -%>
+<% if not @db_port.nil? -%>
+    DB Port = "<%= @db_port %>";
+<% end -%>
 }

--- a/templates/bacula-dir-header.erb
+++ b/templates/bacula-dir-header.erb
@@ -32,5 +32,6 @@ Catalog {
     Name   = MyCatalog
     dbname = "<%= @db_name %>";
     dbuser = "<%= @db_user %>";
-    dbpassword = "<%= @db_pw %>"
+    dbpassword = "<%= @db_pw %>";
+    DB Address = "<%= @db_host %>"
 }


### PR DESCRIPTION
Add options to specify the database host and port if they are not default.

Postgresql 9.5 sets the default to allow peer access via sockets, which doesn't work because both the bacula services run as root.

Setting the db host to 'localhost' (and being able to set the port if necessary) allows it to work over tcp/ip rather than sockets which means it can use a password.

They are both set to undef by default to retain current behaviour and try to use a socket connection instead.
