### PR TITLE
if there is an existing make_postgresql_tables that comes with the di…

### DIFF
--- a/manifests/director/postgresql.pp
+++ b/manifests/director/postgresql.pp
@@ -36,13 +36,14 @@ class bacula::director::postgresql(
 
     default: {
       $make_bacula_tables_file = false
-      file { $make_bacula_tables:
-        content => template('bacula/make_bacula_postgresql_tables.erb'),
-        owner   => $user,
-        mode    => '0750',
-        before  => Exec["/bin/sh ${make_bacula_tables}"]
-      }
     }
+  }
+
+  file { $make_bacula_tables:
+    content => template('bacula/make_bacula_postgresql_tables.erb'),
+    owner   => $user,
+    mode    => '0750',
+    before  => Exec["/bin/sh ${make_bacula_tables}"]
   }
 
   exec { "/bin/sh ${make_bacula_tables}":


### PR DESCRIPTION
…stro, use that instead of creating a template. this avoids the problem where a distro might be behind the latest version of bacula and thus not be able to use the latest version of the database.

Redhat/Centos6 bacula wants v12 of the database not v14 that the template provides.
