### PR TITLE
Add job_tag parameter, a string that might be used for grouping of jobs.

### DIFF
--- a/manifests/director.pp
+++ b/manifests/director.pp
@@ -101,7 +101,7 @@ class bacula::director (
   Bacula::Director::Storage <<||>> { conf_dir => $conf_dir }
   Bacula::Director::Client <<||>> { conf_dir => $conf_dir }
 
-  if $job_tag {
+  if !empty($job_tag) {
     Bacula::Director::Job <<| tag == $job_tag |>> { conf_dir => $conf_dir }
   } else {
     Bacula::Director::Job <<||>> { conf_dir => $conf_dir }

--- a/manifests/director.pp
+++ b/manifests/director.pp
@@ -32,6 +32,7 @@ class bacula::director (
   $director_address    = $bacula::params::director_address,
   $storage             = $bacula::params::storage,
   $group               = $bacula::params::bacula_group,
+  $job_tag             = $bacula::params::job_tag,
 ) inherits bacula::params {
 
   include bacula::common
@@ -99,7 +100,12 @@ class bacula::director (
   Bacula::Director::Pool <<||>> { conf_dir => $conf_dir }
   Bacula::Director::Storage <<||>> { conf_dir => $conf_dir }
   Bacula::Director::Client <<||>> { conf_dir => $conf_dir }
-  Bacula::Director::Job <<||>> { conf_dir => $conf_dir }
+
+  if $job_tag {
+    Bacula::Director::Job <<| tag == $job_tag |>> { conf_dir => $conf_dir }
+  } else {
+    Bacula::Director::Job <<||>> { conf_dir => $conf_dir }
+  }
 
   Bacula::Fileset <<||>> { conf_dir => $conf_dir }
 

--- a/manifests/job.pp
+++ b/manifests/job.pp
@@ -91,8 +91,14 @@ define bacula::job (
     $fileset_real = 'Common'
   }
 
+  if empty($job_tag) {
+    $real_tags = "bacula-${::bacula::params::director}"
+  } else {
+    $real_tags = ["bacula-${::bacula::params::director}", $job_tag]
+  }
+
   @@bacula::director::job { $name:
     content => template($template),
-    tag     => ["bacula-${::bacula::params::director}", $job_tag];
+    tag     => $real_tags,
   }
 }

--- a/manifests/job.pp
+++ b/manifests/job.pp
@@ -24,6 +24,8 @@
 #     set to false to disable this option
 #   * priority - string containing the priority number for the job
 #     set to false to disable this option
+#   * job_tag - string that might be used for grouping of jobs. Pass this to
+#     bacula::director to only collect jobs that match this tag.
 #
 # Actions:
 #   * Exports job fragment for consuption on the director
@@ -63,6 +65,7 @@ define bacula::job (
   $restoredir          = '/tmp/bacula-restores',
   $sched               = false,
   $priority            = false,
+  $job_tag             = $bacula::params::job_tag,
 ) {
   validate_array($files)
   validate_array($excludes)
@@ -90,6 +93,6 @@ define bacula::job (
 
   @@bacula::director::job { $name:
     content => template($template),
-    tag     => "bacula-${::bacula::params::director}";
+    tag     => ["bacula-${::bacula::params::director}", $job_tag];
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -22,6 +22,7 @@ class bacula::params {
   $storage          = hiera('bacula::params::storage', $::fqdn)
   $director         = hiera('bacula::params::director', $::fqdn)
   $director_address = hiera('bacula::params::director_address', $director)
+  $job_tag          = hiera('bacula::params::job_tag', undef)
 
   case $::operatingsystem {
     'Ubuntu','Debian': {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -22,7 +22,7 @@ class bacula::params {
   $storage          = hiera('bacula::params::storage', $::fqdn)
   $director         = hiera('bacula::params::director', $::fqdn)
   $director_address = hiera('bacula::params::director_address', $director)
-  $job_tag          = hiera('bacula::params::job_tag', undef)
+  $job_tag          = hiera('bacula::params::job_tag', '')
 
   case $::operatingsystem {
     'Ubuntu','Debian': {


### PR DESCRIPTION
In our setup, we create groups of servers. One is bacula director+storage, others are clients. But the setup shares a common puppet server and puppetdb. Without this patch, each bacula director collects *all* jobs from every group of servers. With this patch, the bacula director for each group only collects the jobs that were exported with the tag that was provided.

To use it, you can pass the `$job_tag` setting to each class or defined resource, or you can set `bacula::params::job_tag` in your Hiera data. 

In our case, we have set it to:
```
bacula::params::job_tag: "%{::domain}"
```
Each server group in our setup as a different domain, so this ensures the bacula director only receives jobs from clients in the same domain.