### PR TITLE
Job does not export generated Fileset

### DIFF
--- a/manifests/job.pp
+++ b/manifests/job.pp
@@ -80,7 +80,7 @@ define bacula::job (
   } elsif $fileset == true {
     if $files == '' { err('you tell me to create a fileset, but no files given') }
     $fileset_real = $name
-    bacula::fileset { $name:
+    @@bacula::fileset { $name:
       files    => $files,
       excludes => $excludes
       }


### PR DESCRIPTION
Documentation of the bacula::job class says:
"...
fileset - If set to true, a fileset will be genereated based on the files
     and exclides paramaters specified above 
...",
however it does not work. The reason is that at job.pp:83 the fileset is no exported.