### PR TITLE
Added documentation and collect Bacula::Fileset, Bacula::Client based on tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,9 @@ bacula::client::default_pool: 'Corp'
 In order for clients to be able to define jobs on the director, exported
 resources are used, thus there was a reliance on PuppetDB availability in the
 environment. In the client manifest the `bacula::job` exports a job 
-definition to the director. 
+definition to the director. If you deploy multiple directors that use the
+same PuppetDB and you don't want each director to collect every job, specify
+a job_tag to group them.
 
 ```puppet
 bacula::job { 'obsidian_logs':
@@ -194,7 +196,7 @@ to backup the files or directories at the paths specified in the `files`
 parameter.
 
 If a group of jobs will contain the same files, a [FileSet resource] can be
-used to simplify the `bacula::job` resource.  This can be exported from the
+used to simplify the `bacula::job` resource. This can be exported from the
 node (ensuring the resource title will be unique when realized) or a simple
 resource specified on the director using the `bacula::fileset` defined type as
 follows:
@@ -205,6 +207,8 @@ bacula::fileset { 'Puppet':
   options => {'compression' => 'LZO' }
 }
 ```
+If you set a job_tag on your `bacula::job`, make sure to also set the tag of
+the `bacula::fileset` to the same value.
 
 ## Available types
 

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -63,5 +63,6 @@ class bacula::client (
     port     => $port,
     client   => $client,
     password => $password,
+    tag      => "bacula-${::bacula::params::director}",
   }
 }

--- a/manifests/director.pp
+++ b/manifests/director.pp
@@ -100,15 +100,16 @@ class bacula::director (
 
   Bacula::Director::Pool <<||>> { conf_dir => $conf_dir }
   Bacula::Director::Storage <<||>> { conf_dir => $conf_dir }
-  Bacula::Director::Client <<||>> { conf_dir => $conf_dir }
+  Bacula::Director::Client <<| tag == "bacula-${director}" |>> { conf_dir => $conf_dir }
 
   if !empty($job_tag) {
+    Bacula::Fileset <<| tag == $job_tag |>> { conf_dir => $conf_dir }
     Bacula::Director::Job <<| tag == $job_tag |>> { conf_dir => $conf_dir }
   } else {
+    Bacula::Fileset <<||>> { conf_dir => $conf_dir }
     Bacula::Director::Job <<||>> { conf_dir => $conf_dir }
   }
 
-  Bacula::Fileset <<||>> { conf_dir => $conf_dir }
 
   Concat::Fragment <<| tag == "bacula-${director}" |>>
 

--- a/manifests/director.pp
+++ b/manifests/director.pp
@@ -99,7 +99,7 @@ class bacula::director (
   }
 
   Bacula::Director::Pool <<||>> { conf_dir => $conf_dir }
-  Bacula::Director::Storage <<||>> { conf_dir => $conf_dir }
+  Bacula::Director::Storage <<| tag == "bacula-${storage}" |>> { conf_dir => $conf_dir }
   Bacula::Director::Client <<| tag == "bacula-${director}" |>> { conf_dir => $conf_dir }
 
   if !empty($job_tag) {

--- a/manifests/fileset.pp
+++ b/manifests/fileset.pp
@@ -14,6 +14,6 @@ define bacula::fileset (
   @@concat::fragment { "bacula-fileset-${name}":
     target  => "${conf_dir}/conf.d/fileset.conf",
     content => template('bacula/fileset.conf.erb'),
-    tag     => "bacula-${bacula::params::director}";
+    tag     => "bacula-${::bacula::params::director}",
   }
 }

--- a/manifests/storage.pp
+++ b/manifests/storage.pp
@@ -81,5 +81,6 @@ class bacula::storage (
     device_name   => $device_name,
     media_type    => $media_type,
     maxconcurjobs => $maxconcurjobs,
+    tag           => "bacula-${::bacula::params::storage}",
   }
 }


### PR DESCRIPTION
Without collecting with tags, all client and fileset configurations will be written to the director. 