### PR TITLE
Set db_name environment variable when executing the make_bacula_table…

### DIFF
--- a/manifests/director/postgresql.pp
+++ b/manifests/director/postgresql.pp
@@ -28,6 +28,7 @@ class bacula::director::postgresql(
   exec { "/bin/sh ${make_bacula_tables}":
     user        => $user,
     refreshonly => true,
+    environment => ["db_name=${db_name}"],
     subscribe   => Postgresql::Server::Db[$db_name],
     notify      => Service[$services],
     require     => [


### PR DESCRIPTION
…s script.

This is necessary, because if it isn't set the following error is generated:
```
Info: Postgresql::Server::Db[bacula]: Scheduling refresh of Exec[/bin/sh /usr/share/bacula-director/make_postgresql_tables]
Notice: /Stage[main]/Bacula::Director::Postgresql/Exec[/bin/sh /usr/share/bacula-director/make_postgresql_tables]/returns: psql: FATAL:  database "XXX_DBNAME_XXX" does not exist
Notice: /Stage[main]/Bacula::Director::Postgresql/Exec[/bin/sh /usr/share/bacula-director/make_postgresql_tables]/returns: Creation of Bacula PostgreSQL tables failed.
Error: /Stage[main]/Bacula::Director::Postgresql/Exec[/bin/sh /usr/share/bacula-director/make_postgresql_tables]: Failed to call refresh: /bin/sh /usr/share/bacula-director/make_postgresql_tables returned 2 instead of one of [0]
Error: /Stage[main]/Bacula::Director::Postgresql/Exec[/bin/sh /usr/share/bacula-director/make_postgresql_tables]: /bin/sh /usr/share/bacula-director/make_postgresql_tables returned 2 instead of one of [0]
```
It tries to use the `XXX_DBNAME_XXX` database because of this line in make_postgresql_tables:
```
db_name=${db_name:-XXX_DBNAME_XXX}
```