### PR TITLE
Support jobtypes "Copy" and "Migrate"

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,6 +361,7 @@ Define a Bacula [Pool resource]. Parameters are:
   Bacula `Volume Use Duration` directive.
 - `storage`: name of the `Storage` resource backing the pool.
   Defaults to `$bacula::params::storage`. Bacula `Storage` directive.
+- `next_pool`: specifies that data from a `Copy` or `Migrate` job should go to the provided pool
 
 
 [Component Overview]: http://www.bacula.org/7.0.x-manuals/en/main/What_is_Bacula.html#SECTION00220000000000000000

--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ resources if needed. Parameters are:
   Defaults to `[]`.
 - `excludes`: array of files to exclude in `Bacula::Fileset[$name]`
   Defaults to `[]`.
-- `jobtype`: one of `Backup` (default), `Restore`, `Admin` or `Verify`.
+- `jobtype`: one of `Backup` (default), `Restore`, `Admin`, `Verify`, `Copy` or `Migrate`.
   Defaults to `Backup`. Bacula `Type` directive.
 - `fileset`: determines whether to use the `Common` fileset (`false`), define a
    new `Bacula::Fileset[$name]` (`true`) or use a previously
@@ -276,7 +276,7 @@ See also `bacula::jobdefs`.
 
 Define a Bacula [JobDefs resource] resource. Parameters are:
 
-- `jobtype`: one of `Backup`, `Restore`, `Admin` or `Verify`.  Defaults to
+- `jobtype`: one of `Backup`, `Restore`, `Admin`, `Verify`, `Copy` or `Migrate`.  Defaults to
   `Backup`. Bacula `Type` directive.
 - `sched`: name of the `bacula::schedule` to use.  Defaults to `Default`.
   Bacula `Schedule` directive.

--- a/README.md
+++ b/README.md
@@ -269,6 +269,8 @@ resources if needed. Parameters are:
   Defaults to `false` which disables this directive. Bacula `Schedule` directive.
 - `priority`: the priority of the job.
   Defaults to `false` which disables this directive. Bacula `Priority` directive.
+- `selection_type`: determines how a copy/migration job will go about selecting what JobIds to migrate
+- `selection_pattern`: gives you fine control over exactly what JobIds are selected for a copy/migration job.
 
 See also `bacula::jobdefs`.
 

--- a/manifests/director/pool.pp
+++ b/manifests/director/pool.pp
@@ -41,6 +41,7 @@ define bacula::director::pool (
   $autoprune      = 'Yes',
   $purgeaction    = 'Truncate',
   $conf_dir       = $bacula::params::conf_dir, # Overridden at realize
+  $next_pool      = undef,
 ) {
 
   include bacula::params

--- a/manifests/job.pp
+++ b/manifests/job.pp
@@ -66,8 +66,10 @@ define bacula::job (
   $sched               = false,
   $priority            = false,
   $job_tag             = $bacula::params::job_tag,
+  $selection_type      = undef,
+  $selection_pattern   = undef,
 ) {
-  validate_re($jobtype, ['^Backup', '^Restore', '^Admin', '^Verify'])
+  validate_re($jobtype, ['^Backup', '^Restore', '^Admin', '^Verify', '^Copy', '^Migrate'])
   validate_re($accurate, ['^yes', '^no'])
 
   include bacula::common

--- a/manifests/jobdefs.pp
+++ b/manifests/jobdefs.pp
@@ -23,7 +23,7 @@ define bacula::jobdefs (
   $reschedule_times    = '10',
 ) {
 
-  validate_re($jobtype, ['^Backup', '^Restore', '^Admin', '^Verify'])
+  validate_re($jobtype, ['^Backup', '^Restore', '^Admin', '^Verify', '^Copy', '^Migrate'])
 
   include bacula::params
   $conf_dir = $bacula::params::conf_dir

--- a/templates/bacula-dir-pool.erb
+++ b/templates/bacula-dir-pool.erb
@@ -23,5 +23,8 @@ Pool {
 <% end -%>
     Storage              = <%= @storage %>-sd
     Action On Purge      = <%= @purgeaction %>
+<% if @next_pool -%>
+    Next Pool            = <%= @next_pool %>
+<% end -%>
 }
 

--- a/templates/job.conf.erb
+++ b/templates/job.conf.erb
@@ -24,6 +24,13 @@ Job {
 <% if @pool_diff -%>
     Differential Backup Pool = <%= scope.lookupvar('bacula::params::bacula_storage') %>-Pool-Diff
 <% end -%>
+<% elsif @jobtype == "Copy" or @jobtype == "Migrate" -%>
+<% if @selection_type -%>
+    Selection Type = <%= @selection_type %>
+<% end -%>
+<% if @selection_pattern -%>
+    Selection Type = <%= @selection_pattern %>
+<% end -%>
 <% end -%>
 
 <% if @jobdef -%>


### PR DESCRIPTION
This adds support for the[ "Copy" and "Migrate" job types](http://www.bacula.org/7.4.x-manuals/en/main/Migration_Copy.html). This introduces some new parameters; I've added a short explanation to `README.md`.

By using the "Copy" job type it is possible to setup D2T jobs or off-site backups.