### PR TITLE
Correct FreeBSD default Puppet SSL directory path

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -9,7 +9,10 @@ class bacula::params {
   $autoprune      = 'yes'
   $monitor        = true
   $ssl            = hiera('bacula::params::ssl', false)
-  $ssl_dir        = hiera('bacula::params::ssl_dir', '/etc/puppetlabs/puppet/ssl')
+  $ssl_dir        = hiera('bacula::params::ssl_dir', $facts['osfamily'] ? {
+    /(?i-mx:freebsd)/ => '/var/puppet/ssl',
+    default           => '/etc/puppetlabs/puppet/ssl',
+  })
 
   validate_bool($ssl)
 


### PR DESCRIPTION
Have tested it on Puppet version 4.6 and 3.8 (installed with pkg) to confirm that this is the correct default values

```
root@freebsd-puppet-dev:~ # uname -sr
FreeBSD 10.3-RELEASE-p7
root@freebsd-puppet-dev:~ # puppet --version
4.6.2
root@freebsd-puppet-dev:~ # puppet config print ssldir
/var/puppet/ssl
```

```
root@freebsd-puppet-dev:~ # uname -sr
FreeBSD 10.3-RELEASE-p7
root@freebsd-puppet-dev:~ # puppet --version
3.8.6
root@freebsd-puppet-dev:~ # puppet config print ssldir
/var/puppet/ssl
```