### PR TITLE
Improvements for Messages

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,2 +1,12 @@
 ---
+bacula::director::messages:
+    Daemon:
+      mname:        'Daemon'
+      console:      'all, !skipped, !saved'
+      append:       '"/var/log/bacula/log" = all, !skipped'
+    Standard-dir:
+      mname:        'Standard'
+      console:      'all, !skipped, !saved'
+      append:       '"/var/log/bacula/log" = all, !skipped'
+      catalog:      'all'
 bacula::director::postgresql::make_bacula_tables: ''

--- a/manifests/director.pp
+++ b/manifests/director.pp
@@ -33,7 +33,7 @@ class bacula::director (
   $storage             = $bacula::params::storage,
   $group               = $bacula::params::bacula_group,
   $job_tag             = $bacula::params::job_tag,
-  $messages            = $bacula::params::dir_messages,
+  $messages,
 ) inherits bacula::params {
 
   include bacula::common

--- a/manifests/director.pp
+++ b/manifests/director.pp
@@ -33,6 +33,7 @@ class bacula::director (
   $storage             = $bacula::params::storage,
   $group               = $bacula::params::bacula_group,
   $job_tag             = $bacula::params::job_tag,
+  $messages            = $bacula::params::dir_messages,
 ) inherits bacula::params {
 
   include bacula::common
@@ -87,17 +88,7 @@ class bacula::director (
     content => template('bacula/bacula-dir-tail.erb')
   }
 
-  bacula::messages { 'Standard-dir':
-    console => 'all, !skipped, !saved',
-    append  => '"/var/log/bacula/log" = all, !skipped',
-    catalog => 'all',
-  }
-
-  bacula::messages { 'Daemon':
-    mname   => 'Daemon',
-    console => 'all, !skipped, !saved',
-    append  => '"/var/log/bacula/log" = all, !skipped',
-  }
+  create_resources(bacula::messages, $messages)
 
   Bacula::Director::Pool <<||>> { conf_dir => $conf_dir }
   Bacula::Director::Storage <<| tag == "bacula-${storage}" |>> { conf_dir => $conf_dir }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -11,6 +11,19 @@ class bacula::params {
   $ssl            = hiera('bacula::params::ssl', false)
   $ssl_dir        = hiera('bacula::params::ssl_dir', '/etc/puppetlabs/puppet/ssl')
   $device_seltype = 'bacula_store_t'
+  $dir_messages   = hiera('bacula::params::dir_messages', {
+    'Daemon' => {
+      mname   => 'Daemon',
+      console => 'all, !skipped, !saved',
+      append  => '"/var/log/bacula/log" = all, !skipped',
+    },
+    'Standard-dir' => {
+      mname   => 'Standard',
+      console => 'all, !skipped, !saved',
+      append  => '"/var/log/bacula/log" = all, !skipped',
+      catalog => 'all',
+    }
+  })
 
   validate_bool($ssl)
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -11,19 +11,6 @@ class bacula::params {
   $ssl            = hiera('bacula::params::ssl', false)
   $ssl_dir        = hiera('bacula::params::ssl_dir', '/etc/puppetlabs/puppet/ssl')
   $device_seltype = 'bacula_store_t'
-  $dir_messages   = hiera('bacula::params::dir_messages', {
-    'Daemon' => {
-      mname   => 'Daemon',
-      console => 'all, !skipped, !saved',
-      append  => '"/var/log/bacula/log" = all, !skipped',
-    },
-    'Standard-dir' => {
-      mname   => 'Standard',
-      console => 'all, !skipped, !saved',
-      append  => '"/var/log/bacula/log" = all, !skipped',
-      catalog => 'all',
-    }
-  })
 
   validate_bool($ssl)
 

--- a/templates/messages.erb
+++ b/templates/messages.erb
@@ -4,7 +4,9 @@ Messages {
 <% if @director -%>
     Director = <%= @director %>
 <% end -%>
+<% if @append -%>
     Append   = <%= @append %>
+<% end -%>
 <% if @syslog -%>
     Syslog   = <%= @syslog %>
 <% end -%>


### PR DESCRIPTION
Here's a bug fix and an enhancement.  The commit messages have the details.  I will note that what I did for the Director's Messages should probably be extended to those for the Client and Storage, but I didn't need any customization there so I left them alone.  If this were done, Define[bacula::messages] should be documented as private since there would no longer be any need to use it directly.