### PR TITLE
fileset: options -> replace string by variant

### DIFF
--- a/manifests/fileset.pp
+++ b/manifests/fileset.pp
@@ -5,7 +5,7 @@
 define bacula::fileset (
   $files,
   $excludes                     = '',
-  Hash[String, Variant] $options = {'signature' => 'SHA1', 'compression' => 'GZIP9'},
+  Hash[String, Variant[String, Array]] $options = {'signature' => 'SHA1', 'compression' => 'GZIP9'},
   $conf_dir                     = $bacula::params::conf_dir, # Overridden at realize
 ) {
 

--- a/manifests/fileset.pp
+++ b/manifests/fileset.pp
@@ -5,7 +5,7 @@
 define bacula::fileset (
   $files,
   $excludes                     = '',
-  Hash[String, String] $options = {'signature' => 'SHA1', 'compression' => 'GZIP9'},
+  Hash[String, Variant] $options = {'signature' => 'SHA1', 'compression' => 'GZIP9'},
   $conf_dir                     = $bacula::params::conf_dir, # Overridden at realize
 ) {
 


### PR DESCRIPTION
the parameter options in defined resource bacula::fileset requires Hash [String, String] but in the template it would also accept a hash.

i changed the second parameter from String to Variant and now you can do such things like
...
    options:
      compression: "GZIP"
      fstype:
        - "ext4"
        - "simfs"
        - "zfs"

