### PR TITLE
fix: exported resource must not use params::director

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -70,6 +70,6 @@ class bacula::client (
     autoprune      => $autoprune,
     file_retention => $file_retention,
     job_retention  => $job_retention,
-    tag            => "bacula-${::bacula::params::director}",
+    tag            => "bacula-${director}",
   }
 }


### PR DESCRIPTION
fixes the tag used for the exported resource (@@bacula::director::client) in client.pp.
the default produces the wrong tag so the exported resource cannot be found.