### PR TITLE
Fix trusted fact reference

### DIFF
--- a/manifests/storage.pp
+++ b/manifests/storage.pp
@@ -25,7 +25,7 @@ class bacula::storage (
   $conf_dir       = $bacula::conf_dir,
   $device         = '/bacula',
   $device_mode    = '0770',
-  $device_name    = "${trusted['fqdn']}-device",
+  $device_name    = "${trusted['certname']}-device",
   $device_owner   = $bacula::bacula_user,
   $device_seltype = $bacula::device_seltype,
   $director_name  = $bacula::director_name,


### PR DESCRIPTION
As smortex has pointed out, the $trusted['fqdn'] fact does not exist.  The
certname was the target default here.  This patch corrects the intended default
value to use the certname from the certificate trusted data.