### PR TITLE
Disable openssl timeout

### DIFF
--- a/manifests/ssl.pp
+++ b/manifests/ssl.pp
@@ -78,7 +78,7 @@ class bacula::ssl (
     path    => '/usr/bin:/usr/sbin:/bin:/sbin:/usr/local/bin:/usr/local/sbin',
     cwd     => "${conf_dir}/ssl",
     creates => "${conf_dir}/ssl/dh2048.pem",
-    timeout => '1800',
+    timeout => 0,
     require => File["${conf_dir}/ssl"],
   }
 }


### PR DESCRIPTION
Generating DH params on slow machine can take more than half an hour…
We have 50.00 BogoMIPS machines here :cold_sweat:!