### PR TITLE
Add Maximum Concurrent Jobs settings to Job/JobDef

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ primary hiera that used these values will need to be updated.
 
 The variables used to specify the Storage and Director host have been moved.
 Where previously, `bacula::params::director` and `bacula::params::storage`,
-replace them with `bacula::dirctor_name` and `bacula::storage_name`.
+replace them with `bacula::director_name` and `bacula::storage_name`.
 
 Here are is the list of variables that have moved out of the params class.  If
 any of these are set in an environments hiera data, they will not be respected

--- a/manifests/director.pp
+++ b/manifests/director.pp
@@ -128,7 +128,7 @@ class bacula::director (
   Bacula::Director::Client <<| tag == "bacula-${director}" |>> { conf_dir => $conf_dir }
 
   if $job_tag {
-    Bacula::Director::Fileset <<| tag == "bacula-${director}" |>> { conf_dir => $conf_dir }
+    Bacula::Director::Fileset <<| tag == $job_tag |>> { conf_dir => $conf_dir }
     Bacula::Director::Job <<| tag == $job_tag |>> { conf_dir => $conf_dir }
     # TODO tag pool resources on export when job_tag is defined
     Bacula::Director::Pool <<|tag == $job_tag |>> { conf_dir => $conf_dir }
@@ -168,9 +168,10 @@ class bacula::director (
   }
 
   bacula::job { 'RestoreFiles':
-    jobtype  => 'Restore',
-    jobdef   => false,
-    messages => 'Standard',
-    fileset  => 'Common',
+    jobtype             => 'Restore',
+    jobdef              => false,
+    messages            => 'Standard',
+    fileset             => 'Common',
+    max_concurrent_jobs => $max_concurrent_jobs,
   }
 }

--- a/manifests/job.pp
+++ b/manifests/job.pp
@@ -72,6 +72,7 @@ define bacula::job (
   $job_tag                  = $bacula::job_tag,
   $selection_type           = undef,
   $selection_pattern        = undef,
+  $max_concurrent_jobs      = '1',
 ) {
 
   include ::bacula

--- a/manifests/jobdefs.pp
+++ b/manifests/jobdefs.pp
@@ -21,6 +21,7 @@ define bacula::jobdefs (
   $reschedule_on_error = false,
   $reschedule_interval = '1 hour',
   $reschedule_times    = '10',
+  $max_concurrent_jobs = '1',
 ) {
 
   validate_re($jobtype, ['^Backup', '^Restore', '^Admin', '^Verify', '^Copy', '^Migrate'])

--- a/templates/job.conf.erb
+++ b/templates/job.conf.erb
@@ -60,5 +60,8 @@ Job {
     Priority         = <%= @priority %>
 <% end -%>
 <%= scope.function_template(['bacula/_job_reschedule.erb']) -%>
+<% if @max_concurrent_jobs -%>
+    Maximum Concurrent Jobs = <%= @max_concurrent_jobs %>
+<% end -%>
 }
 

--- a/templates/jobdefs.conf.erb
+++ b/templates/jobdefs.conf.erb
@@ -9,5 +9,8 @@ JobDefs {
 <% if @level -%>
     Level    = <%= @level %>
 <% end -%>
+<% if @max_concurrent_jobs -%>
+    Maximum Concurrent Jobs = <%= @max_concurrent_jobs %>
+<% end -%>
 <%= scope.function_template(['bacula/_job_reschedule.erb']) -%>
 }


### PR DESCRIPTION
This will allow us to run multiple jobs simultaneously on one Director.
Also fixes the collection of Fileset resources when a job_tag was used and a small typo in the README.md.