### PR TITLE
Various fixes and improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 ## Unreleased
-* Params that need documenting:
-refactor ssl data
+* refactor ssl variable references
+* relocate default client pool and package data to hiera
+* Fix use pool name when job or client request pool_{full,inc, diff} by name
+* encourage hiera for class params
+* fix job_tag reference
+* Improve classification documentation in the README
+* Fix template name template reference fixes #87
+* Fix missing variable references fixes #95
 
 ## 2017-04-16 5.0.0
 ### Summary

--- a/README.md
+++ b/README.md
@@ -12,7 +12,12 @@ A puppet module for the Bacula backup system.
 
 # Requirements
 
-This module requires that [exported resources] have been setup (e.g. with [PuppetDB]).  Including manifests on the Bacula client, assumes that it can export bits of data to the director to end up with fully functional configs.  As such, to get the benefits of using this module, you should be using it on at least the director and client, and most likely the storage, though this might be gotten around, if one were so inclined.
+This module requires that [exported resources] have been setup (e.g. with
+[PuppetDB]).  Including manifests on the Bacula client, assumes that it can
+export bits of data to the director to end up with fully functional configs.
+As such, to get the benefits of using this module, you should be using it on at
+least the director and client, and most likely the storage, though this might
+be gotten around, if one were so inclined.
 
 ## Usage
 
@@ -24,8 +29,8 @@ useful start to begin understanding the moving parts.
 What follows here is the bare minimum you would need to get a fully functional
 Bacula environment with Puppet.  This setup assumes that the three components
 of Bacula (Director, Storage, and Client) all run on three separate nodes.  If
-desired, there is no reason this setup can not be build up on a single node,
-just updating the hostnames used below to all point to the same system.
+desired, there is no reason this setup can not be built on a single node, just
+updating the hostnames used below to all point to the same system.
 
 #### Defaults
 
@@ -41,11 +46,19 @@ bacula::storage_name: 'mystorage.example.com'
 bacula::director_name: 'mydirector.example.com'
 ```
 
+##### Classification
+
 This may be on the same host, or different hosts, but the name you put here 
 should be the fqdn of the target system.  The Director will require the 
 classification of `bacula::director`, and the Storage node will require the 
-classification of `bacula::storage`.  All nodes will require classification of
- `bacula::client`.
+classification of `bacula::storage`.  **All nodes will require classification of
+ `bacula::client`.**
+
+##### Prefer hiera data
+
+Users should prefer setting hiera data to set class parameter values where
+possible.  A couple calls in this module rely on hiera data present to avoid
+scoping issues associated with defined types and default values.
 
 ##### ** Upgrading to 5.x **
 

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -22,4 +22,8 @@ bacula::director_address: '%{trusted.certname}'
 bacula::job_tag: ~
 
 bacula::client::services: 'bacula-fd'
-
+bacula::client::packages: ~
+bacula::client::default_pool: 'Default'
+bacula::client::default_pool_full: ~
+bacula::client::default_pool_inc: ~
+bacula::client::default_pool_diff: ~

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -22,6 +22,10 @@
 class bacula::client (
   String $packages,
   String $services,
+  String $default_pool,
+  Optional[String] $default_pool_full,
+  Optional[String] $default_pool_inc,
+  Optional[String] $default_pool_diff,
   String $port         = '9102',
   $listen_address      = $facts['ipaddress'],
   $password            = 'secret',
@@ -32,10 +36,6 @@ class bacula::client (
   $job_retention       = '6 months',
   $client              = $trusted['certname'],
   $address             = $facts['fqdn'],
-  $default_pool        = 'Default',
-  $default_pool_full   = undef,
-  $default_pool_inc    = undef,
-  $default_pool_diff   = undef,
 ) inherits bacula {
 
   $group    = $::bacula::bacula_group

--- a/manifests/director.pp
+++ b/manifests/director.pp
@@ -9,7 +9,7 @@
 # @param director_address
 # @param group
 # @param homedir
-# @param job_tag
+# @param job_tag A string to use when realizing jobs and filesets
 # @param listen_address
 # @param max_concurrent_jobs
 # @param messages

--- a/manifests/director/job.pp
+++ b/manifests/director/job.pp
@@ -25,6 +25,6 @@ define bacula::director::job (
     target  => "${conf_dir}/conf.d/job.conf",
     content => $content,
     order   => $name,
-    tag     => "bacula-${::bacula::director}",
+    tag     => "bacula-${::bacula::director_name}",
   }
 }

--- a/manifests/job.pp
+++ b/manifests/job.pp
@@ -15,11 +15,11 @@
 # @param job_tag - string that might be used for grouping of jobs. Pass this to bacula::director to only collect jobs that match this tag.
 # @param jobtype
 # @param template
-# @param pool
-# @param pool_full
-# @param pool_inc
-# @param pool_diff
-# @param storate
+# @param pool - string name of the pool to use by default for this job
+# @param pool_full - string name of the pool to use for Full jobs
+# @param pool_inc - string name of the pool to use for Incremental jobs
+# @param pool_diff - string name of the pool to use for Differential jobs
+# @param storage
 # @param jobdef
 # @param level
 # @param accurate
@@ -48,31 +48,31 @@
 #   }
 #
 define bacula::job (
-  Optional[Array] $files    = undef,
-  Optional[Array] $excludes = undef,
-  Optional[String] $fileset = undef,
-  Bacula::JobType $jobtype  = 'Backup',
-  $template                 = 'bacula/job.conf.erb',
-  $pool                     = $bacula::client::default_pool,
-  $pool_full                = $bacula::client::default_pool_full,
-  $pool_inc                 = $bacula::client::default_pool_inc,
-  $pool_diff                = $bacula::client::default_pool_diff,
-  $storage                  = undef,
-  $jobdef                   = 'Default',
-  Array $runscript          = [],
-  $level                    = undef,
-  Pattern[/^yes/, /^no/] $accurate                 = 'no',
-  $reschedule_on_error      = false,
-  $reschedule_interval      = '1 hour',
-  $reschedule_times         = '10',
-  $messages                 = false,
-  $restoredir               = '/tmp/bacula-restores',
-  $sched                    = false,
-  $priority                 = false,
-  $job_tag                  = $bacula::job_tag,
-  $selection_type           = undef,
-  $selection_pattern        = undef,
-  $max_concurrent_jobs      = '1',
+  Optional[Array] $files           = undef,
+  Optional[Array] $excludes        = undef,
+  Optional[String] $fileset        = undef,
+  Bacula::JobType $jobtype         = 'Backup',
+  $template                        = 'bacula/job.conf.erb',
+  Optional[String] $pool           = lookup('bacula::client::default_pool'),
+  Optional[String] $pool_full      = lookup('bacula::client::default_pool_full'),
+  Optional[String] $pool_inc       = lookup('bacula::client::default_pool_inc'),
+  Optional[String] $pool_diff      = lookup('bacula::client::default_pool_diff'),
+  $storage                         = undef,
+  $jobdef                          = 'Default',
+  Array $runscript                 = [],
+  $level                           = undef,
+  Pattern[/^yes/, /^no/] $accurate = 'no',
+  $reschedule_on_error             = false,
+  $reschedule_interval             = '1 hour',
+  $reschedule_times                = '10',
+  $messages                        = false,
+  $restoredir                      = '/tmp/bacula-restores',
+  $sched                           = false,
+  $priority                        = false,
+  Optional[String] $job_tag        = undef,
+  $selection_type                  = undef,
+  $selection_pattern               = undef,
+  $max_concurrent_jobs             = '1',
 ) {
 
   include ::bacula
@@ -87,7 +87,11 @@ define bacula::job (
   if $job_tag {
     $resource_tags = $tag_defaults + [$job_tag]
   } else {
-    $resource_tags = $tag_defaults
+    if $::bacula::job_tag {
+      $resource_tags = $tag_defaults + [$::bacula::job_tag]
+    } else {
+      $resource_tags = $tag_defaults
+    }
   }
 
   if $fileset {

--- a/manifests/ssl.pp
+++ b/manifests/ssl.pp
@@ -12,16 +12,15 @@
 # TODO make DH key length configurable
 #
 class bacula::ssl (
-  #Array $packages            = [],
   String $ssl_dir,
 ) {
 
   include ::bacula
   include ::bacula::client
 
-  $conf_dir     = $::bacula::conf_dir
-  $bacula_user  = $::bacula::bacula_user
-  $bacula_group = $::bacula::bacula_group
+  $conf_dir        = $::bacula::conf_dir
+  $bacula_user     = $::bacula::bacula_user
+  $bacula_group    = $::bacula::bacula_group
 
   $certfile = "${conf_dir}/ssl/${trusted['certname']}_cert.pem"
   $keyfile  = "${conf_dir}/ssl/${trusted['certname']}_key.pem"
@@ -37,7 +36,6 @@ class bacula::ssl (
     owner   => $bacula_user,
     group   => '0',
     mode    => '0640',
-    require => Package[$bacula::client::packages],
   }
 
   file { "${conf_dir}/ssl":

--- a/templates/bacula-fd-header.erb
+++ b/templates/bacula-fd-header.erb
@@ -20,7 +20,7 @@ Director {
 }
 
 FileDaemon {
-    Name                    = <%= @clientcert %>-fd
+    Name                    = <%= @client %>-fd
 <% if @listen_address -%>
     FDAddresses             = {
 <%= scope.function_template(['bacula/_listen.erb']) -%>

--- a/templates/job.conf.erb
+++ b/templates/job.conf.erb
@@ -16,13 +16,13 @@ Job {
 <%   end -%>
 <% elsif @jobtype == "Backup" -%>
 <% if @pool_full -%>
-    Full Backup Pool         = <%= scope.lookupvar('bacula::storage') %>-Pool-Full
+    Full Backup Pool         = <%= @pool_full %>
 <% end -%>
 <% if @pool_inc -%>
-    Incremental Backup Pool  = <%= scope.lookupvar('bacula::storage') %>-Pool-Inc
+    Incremental Backup Pool  = <%= @pool_inc %>
 <% end -%>
 <% if @pool_diff -%>
-    Differential Backup Pool = <%= scope.lookupvar('bacula::storage') %>-Pool-Diff
+    Differential Backup Pool = <%= @pool_diff %>
 <% end -%>
 <% elsif @jobtype == "Copy" or @jobtype == "Migrate" -%>
 <% if @selection_type -%>


### PR DESCRIPTION
* refactor ssl variable references
* relocate default client pool and package data to hiera
* Fix use pool name when job or client request pool_{full,inc, diff} by name
* encourage hiera for class params
* fix job_tag reference
* Improve classification documentation in the README
* Fix template name template reference fixes #87
* Fix missing variable references fixes #95