### PR TITLE
Introduce PKI support

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,10 +234,28 @@ The `pki_signatures` and `pki_encryption` parameters are boolean values
 indicating if backups should be encrypted and/or signed.
 
 The `pki_keypair` and `pki_master_key` parameters should contain the path to
-certificates files.  It's up to the user of the module to determine how to
-manage these certificates (e.g. using a `file` resource to distribute
-certificates through Puppet, or an `exec` resource to build the certificate on
-the node itself).
+certificates files.
+
+```
+bacula::client::pki_encryption: true
+bacula::client::pki_signatures: true
+bacula::client::pki_keypair: /etc/bacula/ssl/pki-keypair.pem
+```
+
+It's up to the user of the module to determine how to manage these certificates
+(e.g. using a `file` resource to distribute certificates through Puppet, or an
+`exec` resource to build the certificate on the node itself).  The following
+example assumes you distributes certificats with Puppet:
+
+```
+file { "/etc/bacula/ssl/pki-keypair.pem":
+  ensure => file,
+  owner  => 'bacula',
+  group  => 'bacula',
+  mode   => '0400',
+  source => "puppet://bacula-certificates/${trusted['certname']}.crt+key.pem",
+}
+```
 
 ## Creating Backup Jobs
 

--- a/README.md
+++ b/README.md
@@ -223,6 +223,22 @@ following data.
 bacula::client::default_pool: 'Corp'
 ```
 
+#### Data Encryption
+
+Bacula [data encryption and signing
+feature](http://www.bacula.org/7.0.x-manuals/en/main/Data_Encryption.html) is
+available in the `bacula::client` class using the `pki_signatures`,
+`pki_encryption`, `pki_keypair` and `pki_master_key` parameters.
+
+The `pki_signatures` and `pki_encryption` parameters are boolean values
+indicating if backups should be encrypted and/or signed.
+
+The `pki_keypair` and `pki_master_key` parameters should contain the path to
+certificates files.  It's up to the user of the module to determine how to
+manage these certificates (e.g. using a `file` resource to distribute
+certificates through Puppet, or an `exec` resource to build the certificate on
+the node itself).
+
 ## Creating Backup Jobs
 
 In order for clients to be able to define jobs on the director, exported

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -36,6 +36,10 @@ class bacula::client (
   $job_retention       = '6 months',
   $client              = $trusted['certname'],
   $address             = $facts['fqdn'],
+  Optional[Boolean] $pki_signatures = undef,
+  Optional[Boolean] $pki_encryption = undef,
+  Optional[String]  $pki_keypair    = undef,
+  Optional[String]  $pki_master_key = undef,
 ) inherits bacula {
 
   $group    = $::bacula::bacula_group
@@ -58,6 +62,8 @@ class bacula::client (
       subscribe => File[$::bacula::ssl::ssl_files],
     }
   }
+
+  $use_pki = ($pki_signatures or $pki_encryption) and $pki_keypair
 
   concat { $config_file:
     owner     => 'root',

--- a/templates/_pki.erb
+++ b/templates/_pki.erb
@@ -1,0 +1,12 @@
+<% if @use_pki -%>
+<% if @pki_signatures -%>
+    PKI Signatures          = <%= @pki_signatures %>
+<% end -%>
+<% if @pki_encryption -%>
+    PKI Encryption          = <%= @pki_encryption %>
+<% end -%>
+    PKI Keypair             = <%= @pki_keypair %>
+<% if @pki_master_key -%>
+    PKI Master Key          = <%= @pki_master_key %>
+<% end -%>
+<% end -%>

--- a/templates/bacula-fd-header.erb
+++ b/templates/bacula-fd-header.erb
@@ -31,4 +31,5 @@ FileDaemon {
     Maximum Concurrent Jobs = <%= @max_concurrent_jobs %>
 <%= scope.function_template(['bacula/_ssl.erb']) -%>
 <%= scope.function_template(['bacula/_sslkeypair.erb']) -%>
+<%= scope.function_template(['bacula/_pki.erb']) -%>
 }


### PR DESCRIPTION
After the discussion in #102, I refactored and squashed our work to enable backups encryption.

This allows us to create a custom bacula fd profile that creates a key, a certificate, combine them and configures the bacula-fd service accordingly.

If this is acceptable, I'll add a commit for adding documentation to README.md.