### PR TITLE
Bug - `-sd` suffix shouldn't be forced on pool storage

### DIFF
--- a/templates/bacula-dir-pool.erb
+++ b/templates/bacula-dir-pool.erb
@@ -22,7 +22,7 @@ Pool {
     Maximum Volume Bytes = <%= @maxvolbytes %>
 <% end -%>
 <% if @storage -%>
-    Storage              = <%= @storage %>-sd
+    Storage              = <%= @storage %>
 <% end -%>
     Action On Purge      = <%= @purgeaction %>
 <% if @next_pool -%>


### PR DESCRIPTION
If the user wishes to have such a suffix, they should pass that as part
of the setting.

This resolves #106.