### PR TITLE
lso set maxconcurjobs for bacula::storage::device

### DIFF
--- a/manifests/storage.pp
+++ b/manifests/storage.pp
@@ -75,7 +75,8 @@ class bacula::storage (
   }
 
   bacula::storage::device { $device_name:
-    device => $device,
+    device        => $device,
+    maxconcurjobs => $maxconcurjobs,
   }
 
   concat::fragment { 'bacula-storage-dir':


### PR DESCRIPTION
Without this, the default of 1 is used, and as a result, the configured infrastructure can only process a single backup at a time, which can cause stalls (We have a customer with a node hosting a huge amount of data and behind a slow connection.  On full backups, this node blocks the whole backup infrastructure of this customer for several days).

Not sure it's the best way to unblock the situation though… So, I did the most straight-forward, thinking that the bottleneck was not on purpose.  Other options I though about are:

* Introduce a new parameter to set `maxconcurjobs` for `bacula::storage::device` only (`$maxconcurjobs` is also used for `@@bacula::director::storage` definition at the end of this file)
* Make the `bacula::storage::device` resource definition optional, allowing the user to define it with the parameters he wants if necessary;
* Use a custom device for this particular node (no change required);
* Do not use the default device, and rather define and use a custom one (no change required).

If you think the way I fixed it is not the best, please advise so that I can move to a better fix :wink: 