### PR TITLE
Improve support of Debian stretch

### DIFF
--- a/data/os/Debian.yaml
+++ b/data/os/Debian.yaml
@@ -1,7 +1,7 @@
 ---
 bacula::director::postgresql::make_bacula_tables: '/usr/share/bacula-director/make_postgresql_tables'
 bacula::director::packages:
-  - 'bacula-director-common'
+  - 'bacula-director'
   - 'bacula-director-<%= $db_type %>'
   - 'bacula-console'
 bacula::director::services: 'bacula-director'
@@ -9,7 +9,6 @@ bacula::director::services: 'bacula-director'
 bacula::client::packages: 'bacula-client'
 bacula::storage::packages:
   - 'bacula-sd'
-  - 'bacula-sd-<%= $db_type %>'
 bacula::storage::services: 'bacula-sd'
 
 bacula::conf_dir: '/etc/bacula'

--- a/data/os/Debian/Debian/7.yaml
+++ b/data/os/Debian/Debian/7.yaml
@@ -1,0 +1,8 @@
+---
+bacula::director::packages:
+  - 'bacula-director-common'
+  - 'bacula-director-<%= $db_type %>'
+  - 'bacula-console'
+bacula::storage::packages:
+  - 'bacula-sd'
+  - 'bacula-sd-<%= $db_type %>'

--- a/data/os/Debian/Debian/8.yaml
+++ b/data/os/Debian/Debian/8.yaml
@@ -1,0 +1,8 @@
+---
+bacula::director::packages:
+  - 'bacula-director-common'
+  - 'bacula-director-<%= $db_type %>'
+  - 'bacula-console'
+bacula::storage::packages:
+  - 'bacula-sd'
+  - 'bacula-sd-<%= $db_type %>'

--- a/spec/classes/director_spec.rb
+++ b/spec/classes/director_spec.rb
@@ -8,7 +8,12 @@ describe 'bacula::director' do
       case facts[:osfamily]
       when 'Debian'
         it { is_expected.to contain_class('bacula::director') }
-        it { is_expected.to contain_package('bacula-director-common') }
+        case facts[:operatingsystemmajrelease]
+        when '7', '8'
+          it { is_expected.to contain_package('bacula-director-common') }
+        when '9'
+          it { is_expected.to contain_package('bacula-director') }
+        end
         it { is_expected.to contain_package('bacula-director-pgsql') }
         it { is_expected.to contain_package('bacula-console') }
       when 'RedHat'

--- a/spec/classes/storage_spec.rb
+++ b/spec/classes/storage_spec.rb
@@ -19,7 +19,10 @@ describe 'bacula::storage' do
       case facts[:osfamily]
       when 'Debian'
         it { is_expected.to contain_package('bacula-sd') }
-        it { is_expected.to contain_package('bacula-sd-pgsql') }
+        case facts[:operatingsystemmajrelease]
+        when '7', '8'
+          it { is_expected.to contain_package('bacula-sd-pgsql') }
+        end
       when 'RedHat'
         case facts[:operatingsystemmajrelease]
         when '6'


### PR DESCRIPTION
We had to setup a new bacula server on Debian Stretch, and there are a few differences in the packages available when comparing with Debian Jessie (oldstable) or Wheezy (oldoldstable).

I chose to default to the most recent requirements for `data/Debian.yaml`, and added two identical override for Debian 7 and Debian 8 (`data/Debian/Debian/{7,8}.yaml`), hoping this is more future proof than overriding the old configuration with the specific settings of Debian 9.