### PR TITLE
Switch to more strict data types

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -26,12 +26,12 @@ class bacula::client (
   Optional[String] $default_pool_full,
   Optional[String] $default_pool_inc,
   Optional[String] $default_pool_diff,
-  String             $port                = '9102', # FIXME: Switch to Integer
+  Integer            $port                = 9102,
   Stdlib::Ip_address $listen_address      = $facts['ipaddress'],
   String             $password            = 'secret',
-  String             $max_concurrent_jobs = '2', # FIXME: Switch to Integer
+  Integer            $max_concurrent_jobs = 2,
   String             $director_name       = $bacula::director_name,
-  String             $autoprune           = 'yes', # FIXME: Switch to Boolean
+  Boolean            $autoprune           = true,
   Bacula::Time       $file_retention      = '45 days',
   Bacula::Time       $job_retention       = '6 months',
   String             $client              = $trusted['certname'],

--- a/manifests/director.pp
+++ b/manifests/director.pp
@@ -49,9 +49,9 @@ class bacula::director (
   String                        $homedir             = $bacula::homedir,
   Optional[String]              $job_tag             = $bacula::job_tag,
   Stdlib::Ip_address            $listen_address      = $facts['ipaddress'],
-  String                        $max_concurrent_jobs = '20', # FIXME: Change type to Integer
+  Integer                       $max_concurrent_jobs = 20,
   String                        $password            = 'secret',
-  String                        $port                = '9101', # FIXME: Change type to Integer
+  Integer                       $port                = 9101,
   String                        $rundir              = $bacula::rundir,
   String                        $storage_name        = $bacula::storage_name,
 ) inherits ::bacula {

--- a/manifests/director/client.pp
+++ b/manifests/director/client.pp
@@ -21,11 +21,11 @@
 #
 define bacula::director::client (
   String       $address,
-  String       $port, # FIXME: CHange type to Integer
+  Integer      $port,
   String       $password,
   Bacula::Time $file_retention,
   Bacula::Time $job_retention,
-  String       $autoprune,
+  Boolean      $autoprune,
   String       $conf_dir = $::bacula::conf_dir,
 ) {
 

--- a/manifests/director/client.pp
+++ b/manifests/director/client.pp
@@ -21,11 +21,11 @@
 #
 define bacula::director::client (
   String       $address,
-  Integer      $port,
+  Variant[String,Integer]      $port, # FIXME: Remove String
   String       $password,
   Bacula::Time $file_retention,
   Bacula::Time $job_retention,
-  Boolean      $autoprune,
+  Variant[String,Boolean]      $autoprune, # FIXME: Remove String
   String       $conf_dir = $::bacula::conf_dir,
 ) {
 

--- a/manifests/director/client.pp
+++ b/manifests/director/client.pp
@@ -26,7 +26,7 @@ define bacula::director::client (
   Bacula::Time $file_retention,
   Bacula::Time $job_retention,
   String       $autoprune,
-  String       $conf_dir = $::bacula::conf_dir
+  String       $conf_dir = $::bacula::conf_dir,
 ) {
 
   concat::fragment { "bacula-director-client-${name}":

--- a/manifests/director/pool.pp
+++ b/manifests/director/pool.pp
@@ -17,23 +17,23 @@
 #   bacula::director::pool {
 #     "PuppetLabsPool-Full":
 #       volret      => "2 months",
-#       maxvolbytes => '2000000000',
-#       maxvoljobs  => '10',
-#       maxvols     => "20",
+#       maxvolbytes => 2000000000,
+#       maxvoljobs  => 10,
+#       maxvols     => 20,
 #       label       => "Full-";
 #   }
 #
 define bacula::director::pool (
   Optional[String] $volret         = undef,
-  Optional[String] $maxvoljobs     = undef, # FIXME: Change type to Integer
-  Optional[String] $maxvolbytes    = undef, # FIXME: Change type to Integer
-  Optional[String] $maxvols        = undef, # FIXME: Change type to Integer
+  Optional[Integer] $maxvoljobs     = undef,
+  Optional[Bacula::Size] $maxvolbytes    = undef,
+  Optional[Integer] $maxvols        = undef,
   Optional[String] $label          = undef,
   Optional[String] $voluseduration = undef,
   String           $storage        = $bacula::director::storage,
   String           $pooltype       = 'Backup',
-  String           $recycle        = 'Yes', # FIXME: Change type to Boolean
-  String           $autoprune      = 'Yes', # FIXME: Change type to Boolean
+  Boolean           $recycle        = true,
+  Boolean           $autoprune      = true,
   String           $purgeaction    = 'Truncate',
   Optional[String] $next_pool      = undef,
   String           $conf_dir       = $::bacula::conf_dir

--- a/manifests/director/pool.pp
+++ b/manifests/director/pool.pp
@@ -25,15 +25,15 @@
 #
 define bacula::director::pool (
   Optional[String] $volret         = undef,
-  Optional[Integer] $maxvoljobs     = undef,
+  Optional[Variant[String,Integer]] $maxvoljobs     = undef, # FIXME: Remove String
   Optional[Bacula::Size] $maxvolbytes    = undef,
-  Optional[Integer] $maxvols        = undef,
+  Optional[Variant[String,Integer]] $maxvols        = undef, # FIXME: Remove String
   Optional[String] $label          = undef,
   Optional[String] $voluseduration = undef,
   String           $storage        = $bacula::director::storage,
   String           $pooltype       = 'Backup',
-  Boolean           $recycle        = true,
-  Boolean           $autoprune      = true,
+  Variant[String,Boolean]           $recycle        = true, # FIXME: Remove String
+  Variant[String,Boolean]           $autoprune      = true, # FIXME: Remove String
   String           $purgeaction    = 'Truncate',
   Optional[String] $next_pool      = undef,
   String           $conf_dir       = $::bacula::conf_dir

--- a/manifests/director/storage.pp
+++ b/manifests/director/storage.pp
@@ -13,11 +13,11 @@
 #
 define bacula::director::storage (
   String $address       = $name,
-  String $port          = '9103', # FIXME: Change type to Integer
+  Integer $port          = 9103,
   String $password      = 'secret',
   String $device_name   = "${::fqdn}-device",
   String $media_type    = 'File',
-  String $maxconcurjobs = '1', # FIXME: Change type to Integer
+  Integer $maxconcurjobs = 1,
   String $conf_dir      = $::bacula::conf_dir
 ) {
 

--- a/manifests/job.pp
+++ b/manifests/job.pp
@@ -61,10 +61,10 @@ define bacula::job (
   Variant[Boolean, String]  $jobdef              = 'Default',
   Array $runscript                 = [],
   Optional[String]  $level               = undef,
-  Enum['yes', 'no'] $accurate            = 'no', # FIXME: Change type to Boolean
+  Boolean           $accurate            = false,
   Boolean           $reschedule_on_error = false,
   Bacula::Time      $reschedule_interval = '1 hour',
-  String            $reschedule_times    = '10', # FIXME: Change type to Integer
+  Integer           $reschedule_times    = 10,
   Optional[String]  $messages            = undef,
   String            $restoredir          = '/tmp/bacula-restores',
   Optional[String]  $sched               = undef,
@@ -72,7 +72,7 @@ define bacula::job (
   Optional[String] $job_tag        = undef,
   Optional[String]  $selection_type      = undef,
   Optional[String]  $selection_pattern   = undef,
-  String            $max_concurrent_jobs = '1', # FIXME: Change type to Integer
+  Integer           $max_concurrent_jobs = 1,
 ) {
 
   include ::bacula

--- a/manifests/jobdefs.pp
+++ b/manifests/jobdefs.pp
@@ -14,14 +14,14 @@ define bacula::jobdefs (
   String           $jobtype             = 'Backup',
   String           $sched               = 'Default',
   String           $messages            = 'Standard',
-  String           $priority            = '10', # FIXME: Change to Integer
+  Integer          $priority            = 10,
   String           $pool                = 'Default',
   Optional[String] $level               = undef,
-  String           $accurate            = 'no', # FIXME: Change to Boolean
+  Boolean          $accurate            = false,
   Boolean          $reschedule_on_error = false,
   Bacula::Time     $reschedule_interval = '1 hour',
-  String           $reschedule_times    = '10', # FIXME: Change to Integer
-  String           $max_concurrent_jobs = '1', # FIXME: Change to Integer
+  Integer          $reschedule_times    = 10,
+  Integer          $max_concurrent_jobs = 1,
 ) {
 
   validate_re($jobtype, ['^Backup', '^Restore', '^Admin', '^Verify', '^Copy', '^Migrate'])

--- a/manifests/storage.pp
+++ b/manifests/storage.pp
@@ -32,10 +32,10 @@ class bacula::storage (
   String             $group          = $bacula::bacula_group,
   String             $homedir        = $bacula::homedir,
   Stdlib::Ip_address $listen_address = $facts['ipaddress'],
-  String             $maxconcurjobs  = '5', # FIXME: Change to Integer
+  Integer            $maxconcurjobs  = 5,
   String             $media_type     = 'File',
   String             $password       = 'secret',
-  String             $port           = '9103', # FIXME: Change to Integer
+  Integer            $port           = 9103,
   String             $rundir         = $bacula::rundir,
   String             $storage        = $trusted['certname'], # storage here is not storage_name
   String             $address        = $facts['fqdn'],

--- a/manifests/storage/device.pp
+++ b/manifests/storage/device.pp
@@ -26,7 +26,7 @@ define bacula::storage::device (
   Boolean          $automatic_mount = true,
   Boolean          $removable_media = false,
   Boolean          $always_open     = false,
-  String           $maxconcurjobs   = '1', # FIXME: Change type to Integer
+  Integer          $maxconcurjobs   = 1,
   String           $conf_dir        = $::bacula::conf_dir,
   Stdlib::Filemode $device_mode     = '0770',
   String           $device_owner    = $bacula::bacula_user,

--- a/spec/type_aliases/size_spec.rb
+++ b/spec/type_aliases/size_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+describe 'Bacula::Size' do
+  context 'valid sizes' do
+    [
+      4096,
+      '1m',
+      '10gb',
+      '4M'
+    ].each do |value|
+      context value.inspect do
+        it { is_expected.to allow_value(value) }
+      end
+    end
+  end
+  context 'invalid sizes' do
+    [
+      '4096',
+      'john',
+      '8 hours',
+      'o12GB1'
+    ].each do |value|
+      context value.inspect do
+        it { is_expected.not_to allow_value(value) }
+      end
+    end
+  end
+end

--- a/templates/bacula-dir-client.erb
+++ b/templates/bacula-dir-client.erb
@@ -6,7 +6,7 @@ Client {
     Password       = "<%= @password %>"
     File Retention = <%= @file_retention %>
     Job Retention  = <%= @job_retention %>
-    AutoPrune      = <%= @autoprune %>
+    AutoPrune      = <%= @autoprune ? 'yes' : 'no' %>
 <%= scope.function_template(['bacula/_tls_client.erb']) %>
 }
 

--- a/templates/bacula-dir-pool.erb
+++ b/templates/bacula-dir-pool.erb
@@ -1,8 +1,8 @@
 Pool {
     Name                 = <%= @name %>
     Pool Type            = <%= @pooltype %>
-    Recycle              = <%= @recycle %>
-    AutoPrune            = <%= @autoprune %>
+    Recycle              = <%= @recycle ? 'yes' : 'no' %>
+    AutoPrune            = <%= @autoprune ? 'yes' : 'no' %>
 <% if @volret -%>
     Volume Retention     = <%= @volret %>
 <% end -%>

--- a/templates/job.conf.erb
+++ b/templates/job.conf.erb
@@ -46,7 +46,7 @@ Job {
       Command = <%= script.fetch('command').inspect %>
     }
 <% end -%>
-    Accurate         = <%= @accurate %>
+    Accurate         = <%= @accurate ? 'yes' : 'no' %>
 <% if @level -%>
     Level            = <%= @level %>
 <% end -%>

--- a/templates/jobdefs.conf.erb
+++ b/templates/jobdefs.conf.erb
@@ -5,7 +5,7 @@ JobDefs {
     Schedule = <%= @sched %>
     Messages = <%= @messages %>
     Priority = <%= @priority %>
-    Accurate = <%= @accurate %>
+    Accurate = <%= @accurate ? 'yes' : 'no' %>
 <% if @level -%>
     Level    = <%= @level %>
 <% end -%>

--- a/types/size.pp
+++ b/types/size.pp
@@ -1,0 +1,6 @@
+type Bacula::Size = Variant[
+  Integer,
+  Pattern[
+    /(?i:\A\d+[mg]b?\Z)/,
+  ],
+]


### PR DESCRIPTION
This Pull-Request enforce stricter data types (e.g. Integer for port number).

While the change is smooth on file daemons where only `bacula-fd` is used, nodes running a director must cope simultaneously with the old and the new data types.  Because the `bacula::director` class create a `bacula::job` (*RestoreFiles*) which is realized on the same host ; if PuppetDB already has a definition of the exported resource, it will not comply with the types requirements.  As a consequence, the catalog compilation will fail and the correct "updated" resource will not replace the old invalid one in the database.

To avoid this dead-end situation, the latest commit temporary adds compatibility with the types previously used.  The plan would be to release a new version of the module with this code, and then revert this patch and release a new version.

Please note however that a transient invalid configuration can occur if a director is updated before the file daemons.  Hopefully, as soon as the file daemons have run puppet once, the exported resources will be fixed in PuppetDB and the next update of the director will restore a valid working configuration.