### PR TITLE
Use the tape group for bacula-sd conf on Debian

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## Unreleased
+Use the correct group (tape) for the bacula-sd configuration file on Debian.
 
 ## 2018-05-13 5.3.0
 Revamp TLS handling and Improve class/define parameter data types.  See the

--- a/data/os/Debian.yaml
+++ b/data/os/Debian.yaml
@@ -7,6 +7,7 @@ bacula::director::packages:
 bacula::director::services: 'bacula-director'
 
 bacula::client::packages: 'bacula-client'
+bacula::storage::group: 'tape'
 bacula::storage::packages:
   - 'bacula-sd'
 bacula::storage::services: 'bacula-sd'


### PR DESCRIPTION
This is a follow-up of https://github.com/xaque208/puppet-bacula/pull/116#issuecomment-392243134

Debian stretch's systemd unit runs the bacula-sd as `bacula:tape`, without secondary groups while previous versions used to start bacula-sd as root, and dropped privileges to `bacula:tape` after reading the configuration.  As a consequence, on recent Debian versions, the daemon cannot read it's configuration file which is owner by `root:bacula` with mode 640.

A simple fix is to use the `tape` group for `bacula-sd.conf` (what this pull-request does).  In make sense to change this for all versions of Debian, not just stretch.