### PR TITLE
Normalize logging accross services

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -3,11 +3,11 @@ bacula::director::messages:
     Daemon:
       mname:        'Daemon'
       console:      'all, !skipped, !saved'
-      append:       '"/var/log/bacula/log" = all, !skipped'
+      append:       '"/var/log/bacula/bacula-dir.log" = all, !skipped'
     Standard-dir:
       mname:        'Standard'
       console:      'all, !skipped, !saved'
-      append:       '"/var/log/bacula/log" = all, !skipped'
+      append:       '"/var/log/bacula/bacula-dir.log" = all, !skipped'
       catalog:      'all'
 bacula::director::postgresql::make_bacula_tables: ''
 bacula::director::db_type: 'pgsql'

--- a/manifests/storage.pp
+++ b/manifests/storage.pp
@@ -76,7 +76,6 @@ class bacula::storage (
   bacula::messages { 'Standard-sd':
     daemon   => 'sd',
     director => "${director_name}-dir = all",
-    syslog   => 'all, !skipped',
     append   => '"/var/log/bacula/bacula-sd.log" = all, !skipped',
   }
 


### PR DESCRIPTION
The default configuration of the three bacula services have some logging inconsistencies regarding where the log files are written and whether messages are send to syslog or not:

| Service | Append to file | Log to syslog |
|-|-|-|
| bacula-dir | `/var/log/bacula/log` | No |
| bacula-fd | `/var/log/bacula/bacula-fd.log` | No |
| bacula-sd | `/var/log/bacula/bacula-sd.log` | Yes |

This pull-request attempts to make things more consistent by always including the service name is the log filename, and not logging to syslog by default (logging to syslog is disabled by default in bacula and is not customizable, so outputing a log of informational messages at priority 'err').