### PR TITLE
Fix variable name @director_name -> @director

### DIFF
--- a/templates/messages.erb
+++ b/templates/messages.erb
@@ -1,8 +1,8 @@
 
 Messages {
     Name     = <%= @mname %>
-<% if @director_name -%>
-    Director = <%= @director_name %>
+<% if @director -%>
+    Director = <%= @director %>
 <% end -%>
 <% if @append -%>
     Append   = <%= @append %>


### PR DESCRIPTION
While converting templates to EPP, I found an undeclared variable used in `templates/messages.erb`.

There is no `@director_name` in the current scope, but an unused `@director` variable may exist.  When using the existing variable, the resulting configuration is adjusted this way:

```diff
diff -Nur bacula.orig/bacula-fd.conf bacula/bacula-fd.conf
--- bacula.orig/bacula-fd.conf  2018-08-01 16:55:15.552571000 +0200
+++ bacula/bacula-fd.conf       2018-08-01 18:31:52.378892000 +0200
@@ -43,9 +43,9 @@
 }
 Messages {
     Name     = Standard
+    Director = marvin.blogreen.org-dir = all, !skipped, !restored
     Append   = "/var/log/bacula/bacula-fd.log" = all, !skipped
 }
 
diff -Nur bacula.orig/bacula-sd.conf bacula/bacula-sd.conf
--- bacula.orig/bacula-sd.conf  2018-08-01 16:55:15.552673000 +0200
+++ bacula/bacula-sd.conf       2018-08-01 20:11:42.553968000 +0200
@@ -16,9 +16,9 @@
 }
 Messages {
     Name     = Standard
+    Director = marvin.blogreen.org-dir = all
     Append   = "/var/log/bacula/bacula-sd.log" = all, !skipped
 }
 
```

The `director` values are from these files:
* https://github.com/xaque208/puppet-bacula/blob/e2593afa00db9a32d9d36ee69c1cb9297e0d29f3/manifests/storage.pp#L76-L80
* https://github.com/xaque208/puppet-bacula/blob/e2593afa00db9a32d9d36ee69c1cb9297e0d29f3/manifests/client.pp#L75-L79

This looks quite consistent to me.  I guess this regression was unnoticed because ERB templates are very forgiving when using the wrong variable names (it just returns `nil`).  On the opposite, EPP require all accessed variable to exist (at least with an `undef` value) and raise an error otherwise.