### PR TITLE
Improve $packages data-types consistency

### DIFF
--- a/data/os/Debian.yaml
+++ b/data/os/Debian.yaml
@@ -6,7 +6,8 @@ bacula::director::packages:
   - 'bacula-console'
 bacula::director::services: 'bacula-director'
 
-bacula::client::packages: 'bacula-client'
+bacula::client::packages:
+  - 'bacula-client'
 bacula::storage::group: 'tape'
 bacula::storage::packages:
   - 'bacula-sd'

--- a/data/os/FreeBSD.yaml
+++ b/data/os/FreeBSD.yaml
@@ -5,7 +5,7 @@ bacula::director::packages: [ 'bacula-server' ]
 bacula::director::services: 'bacula-dir'
 bacula::storage::packages: [ 'bacula-server' ]
 bacula::storage::services: 'bacula-sd'
-bacula::client::packages: 'sysutils/bacula-client'
+bacula::client::packages: [ 'sysutils/bacula-client' ]
 bacula::client::services: 'bacula-fd'
 bacula::conf_dir: '/usr/local/etc/bacula'
 bacula::rundir: '/var/run'

--- a/data/os/OpenBSD.yaml
+++ b/data/os/OpenBSD.yaml
@@ -4,7 +4,7 @@ bacula::director::packages: [ 'bacula-server', "bacula-<%= $db_type %>" ]
 bacula::director::services: 'bacula_dir'
 bacula::storage::packages: [ 'bacula-server' ]
 bacula::storage::services: 'bacula_sd'
-bacula::client::packages: 'bacula-client'
+bacula::client::packages: [ 'bacula-client' ]
 bacula::client::services: 'bacula_fd'
 bacula::conf_dir: '/etc/bacula'
 bacula::rundir: '/var/run'

--- a/data/os/RedHat.yaml
+++ b/data/os/RedHat.yaml
@@ -6,7 +6,7 @@ bacula::storage::packages: [ 'bacula-storage' ]
 bacula::director::packages:
   - 'bacula-director'
   - 'bacula-console'
-bacula::client::packages: 'bacula-client'
+bacula::client::packages: [ 'bacula-client' ]
 
 bacula::director::services: 'bacula-dir'
 bacula::storage::services: 'bacula-sd'

--- a/data/os/Suse.yaml
+++ b/data/os/Suse.yaml
@@ -5,7 +5,7 @@ bacula::storage::packages:
   - 'bacula-sd'
   - 'bacula-sd-<%= $db_type %>'
 bacula::storage::services: [ 'bacula-sd' ]
-bacula::client::packages: 'bacula-client'
+bacula::client::packages: [ 'bacula-client' ]
 bacula::client::services: 'bacula-fd'
 bacula::conf_dir: '/etc/bacula'
 bacula::homedir: '/var/lib/bacula'

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -20,7 +20,7 @@
 #   class { 'bacula::client': director_name => 'mydirector.example.com' }
 #
 class bacula::client (
-  String $packages,
+  Array[String] $packages,
   String $services,
   String $default_pool,
   Optional[String] $default_pool_full,

--- a/manifests/director.pp
+++ b/manifests/director.pp
@@ -34,7 +34,7 @@
 class bacula::director (
   String $db_type,
   Hash[String, Bacula::Message] $messages,
-  Array $packages,
+  Array[String] $packages,
   String $services,
   Boolean $manage_db          = true,
   String $conf_dir            = $bacula::conf_dir,

--- a/manifests/storage.pp
+++ b/manifests/storage.pp
@@ -21,7 +21,7 @@
 #
 class bacula::storage (
   String $services,
-  Array $packages,
+  Array[String] $packages,
   String             $conf_dir       = $bacula::conf_dir,
   String             $device         = '/bacula',
   Stdlib::Filemode   $device_mode    = '0770',


### PR DESCRIPTION
`$bacula::client::packages` was a `String` while `$bacula::director::packages` and `$bacula::storage::packages` where `Array` (without type restriction for the items).

It probably makes sense to consistently use an `Array[String]` for these variables.

End users should be unaffected by this change unless they customized these variables to pass custom package name for `$bacula::client::packages` (which I believe is uncommon).

This problem was found when checking variable data-types consistency while working on switching from erb to epp.