### PR TITLE
Modernize and fix style

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,6 @@ group :test do
   gem 'rspec-puppet', '~> 2.5',                                     :require => false
   gem 'rspec-puppet-facts',                                         :require => false
   gem 'rspec-puppet-utils',                                         :require => false
-  gem 'puppet-lint-absolute_classname-check',                       :require => false
   gem 'puppet-lint-leading_zero-check',                             :require => false
   gem 'puppet-lint-trailing_comma-check',                           :require => false
   gem 'puppet-lint-version_comparison-check',                       :require => false

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -42,8 +42,8 @@ class bacula::client (
   Optional[String]  $pki_master_key = undef,
 ) inherits bacula {
 
-  $group    = $::bacula::bacula_group
-  $conf_dir = $::bacula::conf_dir
+  $group    = $bacula::bacula_group
+  $conf_dir = $bacula::conf_dir
   $config_file = "${conf_dir}/bacula-fd.conf"
 
   package { $packages:

--- a/manifests/common.pp
+++ b/manifests/common.pp
@@ -4,15 +4,15 @@
 #
 class bacula::common {
 
-  include ::bacula
-  include ::bacula::client
+  include bacula
+  include bacula::client
 
-  $conf_dir        = $::bacula::conf_dir
-  $bacula_user     = $::bacula::bacula_user
-  $bacula_group    = $::bacula::bacula_group
-  $homedir         = $::bacula::homedir
-  $homedir_mode    = $::bacula::homedir_mode
-  $client_package  = $::bacula::client::packages
+  $conf_dir        = $bacula::conf_dir
+  $bacula_user     = $bacula::bacula_user
+  $bacula_group    = $bacula::bacula_group
+  $homedir         = $bacula::homedir
+  $homedir_mode    = $bacula::homedir_mode
+  $client_package  = $bacula::client::packages
 
   File {
     ensure  => directory,

--- a/manifests/director.pp
+++ b/manifests/director.pp
@@ -54,13 +54,13 @@ class bacula::director (
   Integer                       $port                = 9101,
   String                        $rundir              = $bacula::rundir,
   String                        $storage_name        = $bacula::storage_name,
-) inherits ::bacula {
+) inherits bacula {
 
-  include ::bacula::director::defaults
+  include bacula::director::defaults
 
   case $db_type {
-    /^(pgsql|postgresql)$/: { include ::bacula::director::postgresql }
-    /^(mysql)$/:            { include ::bacula::director::postgresql }
+    /^(pgsql|postgresql)$/: { include bacula::director::postgresql }
+    /^(mysql)$/:            { include bacula::director::postgresql }
     'none':                 { }
     default:                { fail('No db_type set') }
   }

--- a/manifests/director/client.pp
+++ b/manifests/director/client.pp
@@ -26,7 +26,7 @@ define bacula::director::client (
   Bacula::Time $file_retention,
   Bacula::Time $job_retention,
   Variant[String,Boolean]      $autoprune, # FIXME: Remove String
-  String       $conf_dir = $::bacula::conf_dir,
+  String       $conf_dir = $bacula::conf_dir,
 ) {
 
   concat::fragment { "bacula-director-client-${name}":

--- a/manifests/director/fileset.pp
+++ b/manifests/director/fileset.pp
@@ -15,8 +15,8 @@
 #
 define bacula::director::fileset (
   Array $files,
-  String $conf_dir                              = $::bacula::conf_dir,
-  String $director_name                         = $::bacula::director_name,
+  String $conf_dir                              = $bacula::conf_dir,
+  String $director_name                         = $bacula::director_name,
   Optional[Array] $excludes                     = [],
   Hash[String, Variant[String, Array]] $options = {
     'signature'   => 'SHA1',

--- a/manifests/director/fileset.pp
+++ b/manifests/director/fileset.pp
@@ -14,11 +14,11 @@
 #   }
 #
 define bacula::director::fileset (
-  Array $files,
+  Array[String] $files,
   String $conf_dir                              = $bacula::conf_dir,
   String $director_name                         = $bacula::director_name,
-  Optional[Array] $excludes                     = [],
-  Hash[String, Variant[String, Array]] $options = {
+  Optional[Array[String]] $excludes             = [],
+  Hash[String, Variant[String, Array[String]]] $options = {
     'signature'   => 'SHA1',
     'compression' => 'GZIP9',
   },

--- a/manifests/director/job.pp
+++ b/manifests/director/job.pp
@@ -19,7 +19,7 @@ define bacula::director::job (
   String $conf_dir = $bacula::conf_dir,
 ) {
 
-  include ::bacula
+  include bacula
 
   concat::fragment { "bacula-director-job-${name}":
     target  => "${conf_dir}/conf.d/job.conf",

--- a/manifests/director/pool.pp
+++ b/manifests/director/pool.pp
@@ -36,11 +36,11 @@ define bacula::director::pool (
   Variant[String,Boolean]           $autoprune      = true, # FIXME: Remove String
   String           $purgeaction    = 'Truncate',
   Optional[String] $next_pool      = undef,
-  String           $conf_dir       = $::bacula::conf_dir
+  String           $conf_dir       = $bacula::conf_dir,
 ) {
 
   concat::fragment { "bacula-director-pool-${name}":
     target  => "${conf_dir}/conf.d/pools.conf",
-    content => template('bacula/bacula-dir-pool.erb');
+    content => template('bacula/bacula-dir-pool.erb'),
   }
 }

--- a/manifests/director/postgresql.pp
+++ b/manifests/director/postgresql.pp
@@ -12,13 +12,13 @@ class bacula::director::postgresql (
   String $db_user            = $bacula::director::db_user,
 ) {
 
-  include ::bacula
+  include bacula
 
-  $services = $::bacula::director::services
-  $user     = $::bacula::bacula_user
+  $services = $bacula::director::services
+  $user     = $bacula::bacula_user
 
   if $bacula::director::manage_db {
-    require ::postgresql::server
+    require postgresql::server
     postgresql::server::db { $db_name:
       user     => $db_user,
       password => postgresql_password($db_user, $db_pw),

--- a/manifests/director/storage.pp
+++ b/manifests/director/storage.pp
@@ -18,7 +18,7 @@ define bacula::director::storage (
   String $device_name   = "${::fqdn}-device",
   String $media_type    = 'File',
   Integer $maxconcurjobs = 1,
-  String $conf_dir      = $::bacula::conf_dir
+  String $conf_dir      = $bacula::conf_dir,
 ) {
 
   concat::fragment { "bacula-director-storage-${name}":

--- a/manifests/job.pp
+++ b/manifests/job.pp
@@ -75,7 +75,7 @@ define bacula::job (
   Integer           $max_concurrent_jobs = 1,
 ) {
 
-  include ::bacula
+  include bacula
   $conf_dir = $bacula::conf_dir
 
   if empty($files) and ! $fileset {
@@ -87,8 +87,8 @@ define bacula::job (
   if $job_tag {
     $resource_tags = $tag_defaults + [$job_tag]
   } else {
-    if $::bacula::job_tag {
-      $resource_tags = $tag_defaults + [$::bacula::job_tag]
+    if $bacula::job_tag {
+      $resource_tags = $tag_defaults + [$bacula::job_tag]
     } else {
       $resource_tags = $tag_defaults
     }

--- a/manifests/job.pp
+++ b/manifests/job.pp
@@ -48,8 +48,8 @@
 #   }
 #
 define bacula::job (
-  Optional[Array] $files           = undef,
-  Optional[Array] $excludes        = undef,
+  Optional[Array[String]] $files    = undef,
+  Optional[Array[String]] $excludes = undef,
   Optional[String] $fileset        = undef,
   Bacula::JobType $jobtype         = 'Backup',
   String            $template            = 'bacula/job.conf.erb',
@@ -59,7 +59,7 @@ define bacula::job (
   Optional[String] $pool_diff      = lookup('bacula::client::default_pool_diff'),
   Optional[String]  $storage             = undef,
   Variant[Boolean, String]  $jobdef              = 'Default',
-  Array $runscript                 = [],
+  Array[Hash]       $runscript           = [],
   Optional[String]  $level               = undef,
   Boolean           $accurate            = false,
   Boolean           $reschedule_on_error = false,

--- a/manifests/jobdefs.pp
+++ b/manifests/jobdefs.pp
@@ -26,7 +26,7 @@ define bacula::jobdefs (
 
   validate_re($jobtype, ['^Backup', '^Restore', '^Admin', '^Verify', '^Copy', '^Migrate'])
 
-  include ::bacula
+  include bacula
   $conf_dir = $bacula::conf_dir
 
   concat::fragment { "bacula-jobdefs-${name}":

--- a/manifests/jobdefs.pp
+++ b/manifests/jobdefs.pp
@@ -11,7 +11,7 @@
 # Sample Usage:
 #
 define bacula::jobdefs (
-  String           $jobtype             = 'Backup',
+  Bacula::JobType  $jobtype             = 'Backup',
   String           $sched               = 'Default',
   String           $messages            = 'Standard',
   Integer          $priority            = 10,
@@ -23,8 +23,6 @@ define bacula::jobdefs (
   Integer          $reschedule_times    = 10,
   Integer          $max_concurrent_jobs = 1,
 ) {
-
-  validate_re($jobtype, ['^Backup', '^Restore', '^Admin', '^Verify', '^Copy', '^Migrate'])
 
   include bacula
   $conf_dir = $bacula::conf_dir

--- a/manifests/messages.pp
+++ b/manifests/messages.pp
@@ -27,8 +27,8 @@ define bacula::messages (
 ) {
   validate_re($daemon, ['^dir', '^sd', '^fd'])
 
-  include ::bacula
-  include ::bacula::common
+  include bacula
+  include bacula::common
 
   concat::fragment { "bacula-messages-${daemon}-${name}":
     target  => "${bacula::conf_dir}/bacula-${daemon}.conf",

--- a/manifests/messages.pp
+++ b/manifests/messages.pp
@@ -16,7 +16,7 @@ define bacula::messages (
   Optional[String] $append      = undef,
   Optional[String] $catalog     = undef,
   Optional[String] $console     = undef,
-  String           $daemon      = 'dir',
+  Enum['dir', 'fd', 'sd'] $daemon      = 'dir',
   Optional[String] $director    = undef,
   Optional[String] $mailcmd     = undef,
   Optional[String] $mail        = undef,
@@ -25,8 +25,6 @@ define bacula::messages (
   Optional[String] $operator    = undef,
   Optional[String] $syslog      = undef,
 ) {
-  validate_re($daemon, ['^dir', '^sd', '^fd'])
-
   include bacula
   include bacula::common
 

--- a/manifests/schedule.pp
+++ b/manifests/schedule.pp
@@ -13,7 +13,7 @@
 #   }
 #
 define bacula::schedule (
-  Array $runs,
+  Array[String] $runs,
   String $conf_dir = $bacula::conf_dir,
 ) {
 

--- a/manifests/storage.pp
+++ b/manifests/storage.pp
@@ -40,7 +40,7 @@ class bacula::storage (
   String             $storage        = $trusted['certname'], # storage here is not storage_name
   String             $address        = $facts['fqdn'],
   String             $user           = $bacula::bacula_user,
-) inherits ::bacula {
+) inherits bacula {
 
   # Allow for package names to include EPP syntax for db_type
   $db_type = lookup('bacula::director::db_type')

--- a/manifests/storage/device.pp
+++ b/manifests/storage/device.pp
@@ -27,7 +27,7 @@ define bacula::storage::device (
   Boolean          $removable_media = false,
   Boolean          $always_open     = false,
   Integer          $maxconcurjobs   = 1,
-  String           $conf_dir        = $::bacula::conf_dir,
+  String           $conf_dir        = $bacula::conf_dir,
   Stdlib::Filemode $device_mode     = '0770',
   String           $device_owner    = $bacula::bacula_user,
   String           $device_seltype  = $bacula::device_seltype,


### PR DESCRIPTION
- A leading `::` was required in old puppet versions (up to 3.x), but Puppet 4 and newer does not require this anymore;
- Ensure all parameter are always followed by a `,`.