### PR TITLE
Switch to Hiera 5

### DIFF
--- a/hiera.yaml
+++ b/hiera.yaml
@@ -1,13 +1,16 @@
 ---
-version: 4
-datadir: data
+version: 5
+
+defaults:
+  datadir: 'data'
+  data_hash: 'yaml_data'
+
 hierarchy:
-  - name: "family/name/major"
-    path: "os/%{facts.os.family}/%{facts.os.name}/%{facts.os.release.major}"
-    backend: yaml
+  - name: 'family/name/major'
+    path: 'os/%{facts.os.family}/%{facts.os.name}/%{facts.os.release.major}.yaml'
+
   - name: 'family'
-    path: 'os/%{facts.osfamily}'
-    backend: yaml
+    path: 'os/%{facts.osfamily}.yaml'
+
   - name: 'common'
-    path: 'common'
-    backend: yaml
+    path: 'common.yaml'

--- a/metadata.json
+++ b/metadata.json
@@ -8,7 +8,6 @@
   "project_page": "https://github.com/xaque208/puppet-bacula",
   "issues_url": "https://github.com/xaque208/puppet-bacula/issues",
   "description": "It comes in the night...",
-  "data_provider": "hiera",
   "dependencies": [
     {
       "name": "puppetlabs/concat",


### PR DESCRIPTION
This avoids a bunch of warnings when the Puppet Master use the module:

```
Warning: /usr/local/etc/puppet/environments/production/modules/bacula/hiera.yaml: Use of 'hiera.yaml' version 4 is deprecated. It should be converted to version 5
   (file: /usr/local/etc/puppet/environments/production/modules/bacula/hiera.yaml)
Warning: Defining "data_provider": "hiera" in metadata.json is deprecated.
   (file: /usr/local/etc/puppet/environments/production/modules/bacula/metadata.json)
```

While here, single-quote all strings in hiera.yaml for consistency and
add blanks in a similar fashion to the puppetlabs-ntp module.