### PR TITLE
Update supported dependencies versions

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -27,7 +27,7 @@ class bacula::client (
   Optional[String]        $default_pool_inc,
   Optional[String]        $default_pool_diff,
   Integer                 $port                = 9102,
-  Stdlib::Ip_address      $listen_address      = $facts['ipaddress'],
+  Stdlib::Ip::Address     $listen_address      = $facts['ipaddress'],
   String                  $password            = 'secret',
   Integer                 $max_concurrent_jobs = 2,
   String                  $director_name       = $bacula::director_name,

--- a/manifests/director.pp
+++ b/manifests/director.pp
@@ -48,7 +48,7 @@ class bacula::director (
   String                        $group               = $bacula::bacula_group,
   String                        $homedir             = $bacula::homedir,
   Optional[String]              $job_tag             = $bacula::job_tag,
-  Stdlib::Ip_address            $listen_address      = $facts['ipaddress'],
+  Stdlib::Ip::Address           $listen_address      = $facts['ipaddress'],
   Integer                       $max_concurrent_jobs = 20,
   String                        $password            = 'secret',
   Integer                       $port                = 9101,

--- a/manifests/storage.pp
+++ b/manifests/storage.pp
@@ -31,7 +31,7 @@ class bacula::storage (
   String             $director_name  = $bacula::director_name,
   String             $group          = $bacula::bacula_group,
   String             $homedir        = $bacula::homedir,
-  Stdlib::Ip_address $listen_address = $facts['ipaddress'],
+  Stdlib::Ip::Address $listen_address = $facts['ipaddress'],
   Integer            $maxconcurjobs  = 5,
   String             $media_type     = 'File',
   String             $password       = 'secret',

--- a/manifests/storage.pp
+++ b/manifests/storage.pp
@@ -20,26 +20,26 @@
 # @param user
 #
 class bacula::storage (
-  String             $services,
-  Array[String]      $packages,
-  String             $conf_dir       = $bacula::conf_dir,
-  String             $device         = '/bacula',
-  Stdlib::Filemode   $device_mode    = '0770',
-  String             $device_name    = "${trusted['certname']}-device",
-  String             $device_owner   = $bacula::bacula_user,
-  String             $device_seltype = $bacula::device_seltype,
-  String             $director_name  = $bacula::director_name,
-  String             $group          = $bacula::bacula_group,
-  String             $homedir        = $bacula::homedir,
+  String              $services,
+  Array[String]       $packages,
+  String              $conf_dir       = $bacula::conf_dir,
+  String              $device         = '/bacula',
+  Stdlib::Filemode    $device_mode    = '0770',
+  String              $device_name    = "${trusted['certname']}-device",
+  String              $device_owner   = $bacula::bacula_user,
+  String              $device_seltype = $bacula::device_seltype,
+  String              $director_name  = $bacula::director_name,
+  String              $group          = $bacula::bacula_group,
+  String              $homedir        = $bacula::homedir,
   Stdlib::Ip::Address $listen_address = $facts['ipaddress'],
-  Integer            $maxconcurjobs  = 5,
-  String             $media_type     = 'File',
-  String             $password       = 'secret',
-  Integer            $port           = 9103,
-  String             $rundir         = $bacula::rundir,
-  String             $storage        = $trusted['certname'], # storage here is not storage_name
-  String             $address        = $facts['fqdn'],
-  String             $user           = $bacula::bacula_user,
+  Integer             $maxconcurjobs  = 5,
+  String              $media_type     = 'File',
+  String              $password       = 'secret',
+  Integer             $port           = 9103,
+  String              $rundir         = $bacula::rundir,
+  String              $storage        = $trusted['certname'], # storage here is not storage_name
+  String              $address        = $facts['fqdn'],
+  String              $user           = $bacula::bacula_user,
 ) inherits bacula {
 
   # Allow for package names to include EPP syntax for db_type

--- a/metadata.json
+++ b/metadata.json
@@ -11,7 +11,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/concat",
-      "version_requirement": ">= 1.0.0 < 3.0.0"
+      "version_requirement": ">= 1.0.0 < 5.0.0"
     },
     {
       "name": "puppetlabs/stdlib",
@@ -19,7 +19,7 @@
     },
     {
       "name": "puppetlabs/postgresql",
-      "version_requirement": ">= 4.1.0 < 5.0.0"
+      "version_requirement": ">= 4.1.0 < 6.0.0"
     }
   ],
   "operatingsystem_support": [

--- a/metadata.json
+++ b/metadata.json
@@ -15,7 +15,7 @@
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.25.1 < 5.0.0"
+      "version_requirement": ">= 4.25.1 < 6.0.0"
     },
     {
       "name": "puppetlabs/postgresql",

--- a/templates/_listen.epp
+++ b/templates/_listen.epp
@@ -1,7 +1,7 @@
 <%
   |
     Stdlib::Ip::Address $listen_address,
-    Optional[Integer] $port,
+    Optional[Integer]   $port,
   |
 -%>
 <% $family = address_family($listen_address)

--- a/templates/_listen.epp
+++ b/templates/_listen.epp
@@ -1,6 +1,6 @@
 <%
   |
-    Stdlib::Ip_address $listen_address,
+    Stdlib::Ip::Address $listen_address,
     Optional[Integer] $port,
   |
 -%>


### PR DESCRIPTION
These errors where spotted using:

```
% puppet module list --tree
Warning: Module 'puppetlabs-concat' (v4.2.1) fails to meet some dependencies:
  'zleslie-bacula' (v5.4.0) requires 'puppetlabs-concat' (>= 1.0.0 < 3.0.0)
Warning: Module 'puppetlabs-postgresql' (v5.7.0) fails to meet some dependencies:
  'zleslie-bacula' (v5.4.0) requires 'puppetlabs-postgresql' (>= 4.1.0 < 5.0.0)
```

I have been using the latest version of these modules without incident in respect to the bacula module for quite some time.