### PR TITLE
Added option to not include the director defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ bacula::storage_name: 'mystorage.example.com'
 bacula::director_name: 'mydirector.example.com'
 ```
 
+When using the default settings from this module, some resources get provisioned. The provisioning of these default resources can be disabled with the following parameter.
+
+```
+bacula::director::manage_defaults: false
+```
+
 ##### Classification
 
 This may be on the same host, or different hosts, but the name you put here 

--- a/manifests/director.pp
+++ b/manifests/director.pp
@@ -9,9 +9,9 @@
 # @param director_address
 # @param group
 # @param homedir
-# @param include_defaults
 # @param job_tag A string to use when realizing jobs and filesets
 # @param listen_address
+# @param manage_defaults
 # @param max_concurrent_jobs
 # @param messages
 # @param packages
@@ -48,17 +48,17 @@ class bacula::director (
   String                        $director            = $trusted['certname'], # director here is not bacula::director
   String                        $group               = $bacula::bacula_group,
   String                        $homedir             = $bacula::homedir,
-  Boolean                       $include_defaults    = true,
   Optional[String]              $job_tag             = $bacula::job_tag,
   Stdlib::Ip::Address           $listen_address      = $facts['ipaddress'],
   Integer                       $max_concurrent_jobs = 20,
+  Boolean                       $manage_defaults     = true,
   String                        $password            = 'secret',
   Integer                       $port                = 9101,
   String                        $rundir              = $bacula::rundir,
   String                        $storage_name        = $bacula::storage_name,
 ) inherits bacula {
 
-  if $include_defaults {
+  if $manage_defaults {
     include bacula::director::defaults
 
     bacula::job { 'RestoreFiles':

--- a/manifests/director.pp
+++ b/manifests/director.pp
@@ -60,6 +60,14 @@ class bacula::director (
 
   if $include_defaults {
     include bacula::director::defaults
+
+    bacula::job { 'RestoreFiles':
+      jobtype             => 'Restore',
+      jobdef              => false,
+      messages            => 'Standard',
+      fileset             => 'Common',
+      max_concurrent_jobs => $max_concurrent_jobs,
+    }
   }
 
   case $db_type {
@@ -157,13 +165,5 @@ class bacula::director (
 
   bacula::director::fileset { 'Common':
     files => ['/etc'],
-  }
-
-  bacula::job { 'RestoreFiles':
-    jobtype             => 'Restore',
-    jobdef              => false,
-    messages            => 'Standard',
-    fileset             => 'Common',
-    max_concurrent_jobs => $max_concurrent_jobs,
   }
 }

--- a/manifests/director.pp
+++ b/manifests/director.pp
@@ -9,6 +9,7 @@
 # @param director_address
 # @param group
 # @param homedir
+# @param include_defaults
 # @param job_tag A string to use when realizing jobs and filesets
 # @param listen_address
 # @param max_concurrent_jobs
@@ -47,6 +48,7 @@ class bacula::director (
   String                        $director            = $trusted['certname'], # director here is not bacula::director
   String                        $group               = $bacula::bacula_group,
   String                        $homedir             = $bacula::homedir,
+  Boolean                       $include_defaults    = true,
   Optional[String]              $job_tag             = $bacula::job_tag,
   Stdlib::Ip::Address           $listen_address      = $facts['ipaddress'],
   Integer                       $max_concurrent_jobs = 20,
@@ -56,7 +58,9 @@ class bacula::director (
   String                        $storage_name        = $bacula::storage_name,
 ) inherits bacula {
 
-  include bacula::director::defaults
+  if $include_defaults {
+    include bacula::director::defaults
+  }
 
   case $db_type {
     /^(pgsql|postgresql)$/: { include bacula::director::postgresql }


### PR DESCRIPTION
This pull request adds a simple boolean to be able to not provision the default jobdefs, schedule, pool, ...