### PR TITLE
Switch to Bacula 9 on FreeBSD

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,10 +1,11 @@
 fixtures:
   repositories:
-    stdlib: https://github.com/puppetlabs/puppetlabs-stdlib.git
+    augeas_core:
+      repo: https://github.com/puppetlabs/puppetlabs-augeas_core.git
+      puppet_version: '>= 6.0.0'
     concat: https://github.com/puppetlabs/puppetlabs-concat.git
     postgresql: https://github.com/puppetlabs/puppetlabs-postgresql.git
     puppet: https://github.com/puppetlabs-operations/puppet-puppet.git
+    stdlib: https://github.com/puppetlabs/puppetlabs-stdlib.git
   symlinks:
     bacula: "#{source_dir}"
-
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,18 +16,14 @@ script:
 matrix:
   fast_finish: true
   include:
-  - rvm: 2.1.9
-    env: PUPPET_VERSION="~> 4.0" CHECK=test
-  - rvm: 2.2.6
-    env: PUPPET_VERSION="~> 4.0" CHECK=test
-  - rvm: 2.3.3
-    env: PUPPET_VERSION="~> 4.0" CHECK=test
-  - rvm: 2.4.0
-    env: PUPPET_VERSION="~> 4.0" CHECK=test
-  - rvm: 2.4.0
-    env: PUPPET_VERSION="~> 4.0" CHECK=rubocop
-  - rvm: 2.4.0
-    env: PUPPET_VERSION="~> 4.0" CHECK=build
+  - rvm: 2.4.5
+    env: PUPPET_VERSION="~> 5.0" CHECK=test
+  - rvm: 2.5.3
+    env: PUPPET_VERSION="~> 6.0" CHECK=test
+  - rvm: 2.5.3
+    env: PUPPET_VERSION="~> 6.0" CHECK=rubocop
+  - rvm: 2.4.5
+    env: PUPPET_VERSION="~> 5.0" CHECK=build
 branches:
   only:
   - master

--- a/data/os/FreeBSD.yaml
+++ b/data/os/FreeBSD.yaml
@@ -1,11 +1,11 @@
 ---
 bacula::director::postgresql::make_bacula_tables: '/usr/local/share/bacula/make_postgresql_tables'
 
-bacula::director::packages: [ 'bacula-server' ]
+bacula::director::packages: [ 'bacula9-server' ]
 bacula::director::services: 'bacula-dir'
-bacula::storage::packages: [ 'bacula-server' ]
+bacula::storage::packages: [ 'bacula9-server' ]
 bacula::storage::services: 'bacula-sd'
-bacula::client::packages: [ 'sysutils/bacula-client' ]
+bacula::client::packages: [ 'bacula9-client' ]
 bacula::client::services: 'bacula-fd'
 bacula::conf_dir: '/usr/local/etc/bacula'
 bacula::rundir: '/var/run'

--- a/spec/classes/director_spec.rb
+++ b/spec/classes/director_spec.rb
@@ -34,7 +34,7 @@ describe 'bacula::director' do
         it { is_expected.to contain_package('bacula-server') }
         it { is_expected.to contain_package('bacula-pgsql') }
       when 'FreeBSD'
-        it { is_expected.to contain_package('bacula-server') }
+        it { is_expected.to contain_package('bacula9-server') }
       end
     end
   end

--- a/spec/classes/storage_spec.rb
+++ b/spec/classes/storage_spec.rb
@@ -43,7 +43,7 @@ describe 'bacula::storage' do
       when 'OpenBSD'
         it { is_expected.to contain_package('bacula-server') }
       when 'FreeBSD'
-        it { is_expected.to contain_package('bacula-server') }
+        it { is_expected.to contain_package('bacula9-server') }
       end
 
       context 'with default params' do


### PR DESCRIPTION
`sysutils/bacula-client` and `sysutils/bacula-server` install Bacula 7 which is not supported anymore.  The ports have been marked as [DEPRECATED] in November 2017 with EXPIRATION DATE set to 2019-03-01.

Two new ports where added some times before for Bacula 9:
  - `sysutils/bacula9-client`
  - `sysutils/bacula9-server`

Default to use these up-to-date ports instead of the legacy ones.

[DEPRECATED]: http://svnweb.freebsd.org/changeset/ports/484470