### PR TITLE
"write bootstrap" & "full/diff backup pool"

### DIFF
--- a/manifests/job.pp
+++ b/manifests/job.pp
@@ -29,6 +29,7 @@
 # @param sched
 # @param selection_type
 # @param selection_pattern
+# @param write_bootstrap
 #
 # @actions
 #   * Exports job fragment for consuption on the director
@@ -73,6 +74,7 @@ define bacula::job (
   Optional[String]         $selection_type      = undef,
   Optional[String]         $selection_pattern   = undef,
   Integer                  $max_concurrent_jobs = 1,
+  Optional[String]         $write_bootstrap     = undef,
 ) {
 
   include bacula
@@ -132,6 +134,7 @@ define bacula::job (
     reschedule_on_error => $reschedule_on_error,
     reschedule_interval => $reschedule_interval,
     reschedule_times    => $reschedule_times,
+    write_bootstrap     => $write_bootstrap,
   }
 
   @@bacula::director::job { $name:

--- a/manifests/jobdefs.pp
+++ b/manifests/jobdefs.pp
@@ -16,30 +16,36 @@ define bacula::jobdefs (
   String           $messages            = 'Standard',
   Integer          $priority            = 10,
   String           $pool                = 'Default',
+  Optional[String] $full_backup_pool    = undef,
+  Optional[String] $differential_backup_pool = undef,
   Optional[String] $level               = undef,
   Bacula::Yesno    $accurate            = false,
   Bacula::Yesno    $reschedule_on_error = false,
   Bacula::Time     $reschedule_interval = '1 hour',
   Integer          $reschedule_times    = 10,
   Integer          $max_concurrent_jobs = 1,
+  Optional[String] $write_bootstrap     = undef,
 ) {
 
   include bacula
   $conf_dir = $bacula::conf_dir
 
   $epp_jobdef_variables = {
-    name                => $name,
-    jobtype             => $jobtype,
-    pool                => $pool,
-    sched               => $sched,
-    messages            => $messages,
-    priority            => $priority,
-    accurate            => $accurate,
-    level               => $level,
-    max_concurrent_jobs => $max_concurrent_jobs,
-    reschedule_on_error => $reschedule_on_error,
-    reschedule_interval => $reschedule_interval,
-    reschedule_times    => $reschedule_times,
+    name                      => $name,
+    jobtype                   => $jobtype,
+    pool                      => $pool,
+    full_backup_pool          => $full_backup_pool,
+    differential_backup_pool  => $differential_backup_pool,
+    sched                     => $sched,
+    messages                  => $messages,
+    priority                  => $priority,
+    accurate                  => $accurate,
+    level                     => $level,
+    max_concurrent_jobs       => $max_concurrent_jobs,
+    reschedule_on_error       => $reschedule_on_error,
+    reschedule_interval       => $reschedule_interval,
+    reschedule_times          => $reschedule_times,
+    write_bootstrap           => $write_bootstrap,
   }
 
   concat::fragment { "bacula-jobdefs-${name}":

--- a/templates/job.conf.epp
+++ b/templates/job.conf.epp
@@ -99,5 +99,9 @@ Job {
 <% if $max_concurrent_jobs { -%>
     Maximum Concurrent Jobs = <%= $max_concurrent_jobs %>
 <% } -%>
+<% if $write_bootstrap { -%>
+    Write Bootstrap = <%= $write_bootstrap %>
+<% } -%>
+
 }
 

--- a/templates/job.conf.epp
+++ b/templates/job.conf.epp
@@ -22,6 +22,7 @@
     Bacula::Yesno $reschedule_on_error,
     Bacula::Time $reschedule_interval,
     Integer $reschedule_times,
+    Optional[String] $write_bootstrap,
   |
 -%>
 Job {

--- a/templates/jobdefs.conf.epp
+++ b/templates/jobdefs.conf.epp
@@ -27,10 +27,10 @@ JobDefs {
     Priority = <%= $priority %>
     Accurate = <%= bacula::yesno2str($accurate) %>
 <% if $full_backup_pool { -%>
-    Level    = <%= $full_backup_pool %>
+    Full Backup Pool = <%= $full_backup_pool %>
 <% } -%>
 <% if $differential_backup_pool { -%>
-    Level    = <%= $differential_backup_pool %>
+    Differential Backup Pool = <%= $differential_backup_pool %>
 <% } -%>
 <% if $level { -%>
     Level    = <%= $level %>

--- a/templates/jobdefs.conf.epp
+++ b/templates/jobdefs.conf.epp
@@ -3,6 +3,8 @@
     String $name,
     Bacula::JobType $jobtype,
     String $pool,
+    Optional[String] $full_backup_pool,
+    Optional[String] $differential_backup_pool,
     String $sched,
     String $messages,
     Integer $priority,
@@ -13,6 +15,7 @@
     Bacula::Yesno     $reschedule_on_error,
     Bacula::Time      $reschedule_interval,
     Integer           $reschedule_times,
+    Optional[String]           $write_bootstrap,
   |
 -%>
 JobDefs {

--- a/templates/jobdefs.conf.epp
+++ b/templates/jobdefs.conf.epp
@@ -23,11 +23,20 @@ JobDefs {
     Messages = <%= $messages %>
     Priority = <%= $priority %>
     Accurate = <%= bacula::yesno2str($accurate) %>
+<% if $full_backup_pool { -%>
+    Level    = <%= $full_backup_pool %>
+<% } -%>
+<% if $differential_backup_pool { -%>
+    Level    = <%= $differential_backup_pool %>
+<% } -%>
 <% if $level { -%>
     Level    = <%= $level %>
 <% } -%>
 <% if $max_concurrent_jobs { -%>
     Maximum Concurrent Jobs = <%= $max_concurrent_jobs %>
+<% } -%>
+<% if $write_bootstrap { -%>
+    Write Bootstrap = <%= $write_bootstrap %>
 <% } -%>
 <%= epp('bacula/_job_reschedule.epp', { reschedule_on_error => $reschedule_on_error, reschedule_interval => $reschedule_interval, reschedule_times => $reschedule_times }) -%>
 }


### PR DESCRIPTION
Hi,

this merge request adds:
- support for the "write bootstrap" option in the job and jobdefs defination
- "full / differential backup pool" support for jobdefs.

bootstrap example:
```
  bacula::job { "host-job":
    jobdef    => 'default',
    ....
    write_bootstrap => '/srv/bacula/bootstraps/host',
  }
```
backup pool example:
```
    bacula::jobdefs { "default":
      ....
      full_backup_pool  => "full-pool"
    }
```