### PR TITLE
No more lookup

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -10,7 +10,6 @@ bacula::director::messages:
       append:       '"/var/log/bacula/bacula-dir.log" = all, !skipped'
       catalog:      'all'
 bacula::director::postgresql::make_bacula_tables: ''
-bacula::director::db_type: 'pgsql'
 bacula::director::packages: []
 
 bacula::storage::services: 'bacula-sd'

--- a/data/os/Suse.yaml
+++ b/data/os/Suse.yaml
@@ -1,5 +1,5 @@
 ---
-bacula_director_packages: [ 'bacula-director-common', "bacula-director-${db_type}", 'bacula-console' ]
+bacula_director_packages: [ 'bacula-director-common', "bacula-director-<%= $db_type %>", 'bacula-console' ]
 bacula::director::services: 'bacula-dir'
 bacula::storage::packages:
   - 'bacula-sd'

--- a/manifests/director.pp
+++ b/manifests/director.pp
@@ -3,7 +3,6 @@
 # @param conf_dir
 # @param db_name: the database name
 # @param db_pw: the database user's password
-# @param db_type
 # @param db_user: the database user
 # @param director
 # @param director_address
@@ -33,7 +32,6 @@
 # TODO director_address is only used by bconsole, and is confusing as director is likely the same 
 #
 class bacula::director (
-  String                        $db_type,
   Hash[String, Bacula::Message] $messages,
   Array[String]                 $packages,
   String                        $services,
@@ -70,7 +68,7 @@ class bacula::director (
     }
   }
 
-  case $db_type {
+  case $bacula::db_type {
     /^(pgsql|postgresql)$/: { include bacula::director::postgresql }
     /^(mysql)$/:            { include bacula::director::postgresql }
     'none':                 { }
@@ -80,7 +78,7 @@ class bacula::director (
   # Allow for package names to include EPP syntax for db_type
   $package_names = $packages.map |$p| {
     $package_name = inline_epp($p, {
-      'db_type' => $db_type
+      'db_type' => $bacula::db_type
     })
   }
   ensure_packages($package_names)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -40,6 +40,7 @@ class bacula (
   String                  $director_address,
   String                  $director_name,
   String                  $storage_name,
+  String                  $db_type                 = 'pgsql',
   String                  $homedir_mode            = '0770',
   Bacula::Yesno           $monitor                 = true,
   String                  $device_seltype          = 'bacula_store_t',

--- a/manifests/job.pp
+++ b/manifests/job.pp
@@ -53,10 +53,10 @@ define bacula::job (
   Optional[String]         $fileset             = undef,
   Bacula::JobType          $jobtype             = 'Backup',
   String                   $template            = 'bacula/job.conf.epp',
-  Optional[String]         $pool                = lookup('bacula::client::default_pool'),
-  Optional[String]         $pool_full           = lookup('bacula::client::default_pool_full'),
-  Optional[String]         $pool_inc            = lookup('bacula::client::default_pool_inc'),
-  Optional[String]         $pool_diff           = lookup('bacula::client::default_pool_diff'),
+  Optional[String]         $pool                = undef,
+  Optional[String]         $pool_full           = undef,
+  Optional[String]         $pool_inc            = undef,
+  Optional[String]         $pool_diff           = undef,
   Optional[String]         $storage             = undef,
   Variant[Boolean, String] $jobdef              = 'Default',
   Array[Bacula::Runscript] $runscript           = [],
@@ -76,6 +76,7 @@ define bacula::job (
 ) {
 
   include bacula
+  include bacula::client
   $conf_dir = $bacula::conf_dir
 
   if empty($files) and ! $fileset {
@@ -113,13 +114,13 @@ define bacula::job (
     name                => $name,
     jobtype             => $jobtype,
     fileset_real        => $fileset_real,
-    pool                => $pool,
+    pool                => $pool.lest || { $bacula::client::default_pool },
     storage             => $storage,
     restoredir          => $restoredir,
     messages            => $messages,
-    pool_full           => $pool_full,
-    pool_inc            => $pool_inc,
-    pool_diff           => $pool_diff,
+    pool_full           => $pool_full.lest || { $bacula::client::default_pool_full },
+    pool_inc            => $pool_inc.lest || { $bacula::client::default_pool_inc },
+    pool_diff           => $pool_diff.lest || { $bacula::client::default_pool_diff },
     selection_type      => $selection_type,
     selection_pattern   => $selection_pattern,
     jobdef              => $jobdef,

--- a/manifests/storage.pp
+++ b/manifests/storage.pp
@@ -43,10 +43,9 @@ class bacula::storage (
 ) inherits bacula {
 
   # Allow for package names to include EPP syntax for db_type
-  $db_type = lookup('bacula::director::db_type')
   $package_names = $packages.map |$p| {
     $package_name = inline_epp($p, {
-      'db_type' => $db_type
+      'db_type' => $bacula::db_type
     })
   }
   ensure_packages($package_names)


### PR DESCRIPTION
Relying on `lookup()` has undesired side effects when following the roles & profile pattern recommendations thoroughly.

A user may have configured bacula this way, expecting to use the pool "Target":

```puppet
class profile::bacula_client {
  class { 'bacula::client':
    default_pool => 'Target',
    ...
  }
  ...
}

class profile::my_application {
  include profile::bacula_client

  bacula::job { 'my_application':
    ... (with no explicit pool)
  }
}
```

However, because `bacula::job` use `lookup()`, the job resource fetches the Hiera default value "Default" instead of the value "Target" configured by the user of the module.

This relies on the `lest` function to avoid more verbose conditions.  This function was introduced in Puppet 4.5.0, so I guess it is acceptable?

A similar issue exist with `$bacula::director::db_type` accessed using `lookup()` by the `bacula::storage` class.  It is also fixed by this PR.