### PR TITLE
Use the configured DH parameters with all services

### DIFF
--- a/templates/_tls_server.epp
+++ b/templates/_tls_server.epp
@@ -5,3 +5,6 @@
 <% $bacula::tls_allowed_cn.each |$allowed_cn| { -%>
     TLS Allowed CN          = <%= $allowed_cn %>
 <% } -%>
+<% if $bacula::tls_dh_file { -%>
+    TLS DH File             = <%= $bacula::tls_dh_file %>
+<% } -%>

--- a/templates/bacula-dir-header.epp
+++ b/templates/bacula-dir-header.epp
@@ -12,9 +12,6 @@ Director {                # define myself
     Password                = "<%= $bacula::director::password %>"  # Console password
     Messages                = Daemon
 <%= epp('bacula/_tls_server.epp') %>
-<% if $bacula::director::tls_dh_file != undef { %>
-    TLS DH File             = <%= $bacula::director::tls_dh_file %>
-<% } -%>
 }
 
 # Generic catalog service


### PR DESCRIPTION
Only the director used the DH parameters passed to the bacula class. With this change, the storage daemon and file daemons also use these DH parameters, allowing forward secrecy between all components.

https://www.bacula.org/9.4.x-manuals/en/main/Bacula_TLS_Communications_E.html
> DH key exchange adds an additional level of security because the key used for encryption/decryption by the server and the client is computed on each end and thus is never passed over the network if Diffie-Hellman key exchange is used.