### PR TITLE
Make it easier to set $make_bacula_tables

### DIFF
--- a/manifests/director.pp
+++ b/manifests/director.pp
@@ -23,6 +23,7 @@
 # @param manage_db
 # @param db_address
 # @param db_port
+# @param make_bacula_tables
 #
 # @example
 #   class { 'bacula::director':
@@ -54,6 +55,7 @@ class bacula::director (
   Integer                       $port                = 9101,
   String                        $rundir              = $bacula::rundir,
   String                        $storage_name        = $bacula::storage_name,
+  String                        $make_bacula_tables  = '',
 ) inherits bacula {
 
   if $manage_defaults {

--- a/manifests/director/postgresql.pp
+++ b/manifests/director/postgresql.pp
@@ -6,7 +6,7 @@
 # @param db_user
 #
 class bacula::director::postgresql (
-  String $make_bacula_tables = '',
+  String $make_bacula_tables = $bacula::director::make_bacula_tables,
   String $db_name            = $bacula::director::db_name,
   String $db_pw              = $bacula::director::db_pw,
   String $db_user            = $bacula::director::db_user,


### PR DESCRIPTION
Currently the parameter `$make_bacula_tables` lives in the private class `bacula::director::postgresql`. This class is included by it's parent class `bacula::director` (hence I call it a "private" class).

This makes it pretty hard (impossible?) to set a value for `$make_bacula_tables` from a manifest without causing a duplicate declaration error. (Sure, it's easy to set the value in Hiera, but in certain situations Hiera is not an option.)

This looks like an oversight. I suggest to add this parameter to the parent class `bacula::director` to provide a straightforward way to set it's value. This would nicely align with all other parameters of the `bacula::director::postgresql` class, because they already use the value that is set in the parent class:

```
class bacula::director::postgresql (
  String $make_bacula_tables = '',
  String $db_name            = $bacula::director::db_name,
  String $db_pw              = $bacula::director::db_pw,
  String $db_user            = $bacula::director::db_user,
) {
...
```
