### PR TITLE
Rename of script used to create the PostgreSQL tables

### DIFF
--- a/data/os/RedHat.yaml
+++ b/data/os/RedHat.yaml
@@ -1,5 +1,5 @@
 ---
-bacula::director::postgresql::make_bacula_tables: '/usr/libexec/bacula/make_bacula_tables.postgresql'
+bacula::director::postgresql::make_bacula_tables: '/usr/libexec/bacula/make_bacula_tables'
 bacula::director::db_type: 'postgresql'
 
 bacula::storage::packages: [ 'bacula-storage' ]


### PR DESCRIPTION
The script `/usr/libexec/bacula/make_bacula_tables.postgresql` no longer exists. Instead, `/usr/libexec/bacula/make_bacula_tables` should be run with the type of database as a parameter. In this case, PostgreSQL is the default so no parameter is required.

https://bugzilla.redhat.com/show_bug.cgi?format=multiple&id=835185

Currently, the director installation does not complete correctly with the following error on CentOS 8:

`Error: /Stage[main]/Bacula::Director::Postgresql/Exec[/bin/sh /usr/libexec/bacula/make_bacula_tables.postgresql]: /bin/sh: /usr/libexec/bacula/make_bacula_tables.postgresql: No such file or directory`