### PR TITLE
Output OperatorCommand before Operator

### DIFF
--- a/templates/messages.epp
+++ b/templates/messages.epp
@@ -36,11 +36,11 @@ Messages {
 <% if $mail { -%>
     Mail  = <%= $mail %>
 <% } -%>
-<% if $operator { -%>
-    Operator  = <%= $operator %>
-<% } -%>
 <% if $operatorcmd { -%>
     Operator Command = <%= $operatorcmd %>
+<% } -%>
+<% if $operator { -%>
+    Operator  = <%= $operator %>
 <% } -%>
 }
 


### PR DESCRIPTION
Quotting Bacula documentation:
> The OperatorCommand directive must appear in the Messages resource
> before the Operator directive.

Link to the page in the doc:
https://www.bacula.org/7.4.x-manuals/en/main/Messages_Resource.html